### PR TITLE
fix: replace wrangler with aws CLI for R2 media sync and cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,17 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
 
       - uses: extractions/setup-just@v2
-
-      - name: Install wrangler
-        run: npm install -g wrangler
 
       - name: Determine branch
         id: branch
@@ -41,8 +32,9 @@ jobs:
 
       - name: Sync media to R2
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: just media::sync --prefix ${{ steps.branch.outputs.name }}
 
   # ── Deploy frontend to Cloudflare Pages ──────────────────────────
@@ -172,17 +164,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - uses: extractions/setup-just@v2
-
-      - name: Install wrangler
-        run: npm install -g wrangler
 
       - name: Delete branch media from R2
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: just media::cleanup --branch "${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,8 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     name: Deploy frontend
     runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -77,16 +79,23 @@ jobs:
         run: just app::build-pages
 
       - name: Deploy to Cloudflare Pages
+        id: deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: just app::deploy --branch "${{ steps.branch.outputs.name }}" --project "${{ vars.CLOUDFLARE_PAGES_PROJECT }}"
+        run: |
+          OUTPUT=$(just app::deploy --branch "${{ steps.branch.outputs.name }}" --project "${{ vars.CLOUDFLARE_PAGES_PROJECT }}" 2>&1)
+          echo "$OUTPUT"
+          URL=$(echo "$OUTPUT" | grep -oE 'https://[^ ]*\.pages\.dev' | tail -1)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
 
   # ── Deploy API Worker (preview) on PRs with api/ changes ─────────
   deploy-api-preview:
     if: github.event_name == 'pull_request'
     name: Deploy API (preview)
     runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -113,11 +122,16 @@ jobs:
         run: npm ci
 
       - name: Deploy Worker (preview)
+        id: deploy
         if: steps.changes.outputs.api == 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: just api::deploy --env preview
+        run: |
+          OUTPUT=$(just api::deploy --env preview 2>&1)
+          echo "$OUTPUT"
+          URL=$(echo "$OUTPUT" | grep -oE 'https://[^ ]*\.workers\.dev' | tail -1)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
 
   # ── Deploy API Worker (production) on push to main ───────────────
   deploy-api-production:
@@ -155,6 +169,40 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: just api::deploy --env prod
+
+  # ── Comment preview URLs on PR ───────────────────────────────────
+  comment-preview-urls:
+    if: github.event_name == 'pull_request'
+    name: Comment preview URLs
+    needs: [deploy-pages, deploy-api-preview]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment deploy URLs on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAGES_URL: ${{ needs.deploy-pages.outputs.url }}
+          API_URL: ${{ needs.deploy-api-preview.outputs.url }}
+        run: |
+          MARKER="<!-- deploy-preview-urls -->"
+          BODY="$MARKER
+          ## Preview Deployments
+
+          | Service | URL |
+          |---------|-----|
+          | Frontend | ${PAGES_URL:-_not deployed_} |
+          | API | ${API_URL:-_no changes_} |"
+
+          # Update existing comment or create new one
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- deploy-preview-urls -->")) | .id' | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" -X PATCH -f body="$BODY"
+          else
+            gh pr comment "${{ github.event.pull_request.number }}" -R "${{ github.repository }}" --body "$BODY"
+          fi
 
   # ── Cleanup R2 branch prefix when PR is merged ───────────────────
   cleanup-media:

--- a/just/media.just
+++ b/just/media.just
@@ -2,20 +2,14 @@ set unstable
 
 [doc("Sync media to R2")]
 [arg('prefix', long, help="branch name as R2 key prefix (defaults to current git branch)")]
-[arg('diff_base', long="diff-base", help="commit SHA to diff against for incremental sync")]
 [script('bash')]
-sync prefix="" diff_base="":
+sync prefix="":
     set -euo pipefail
     PREFIX="{{prefix}}"
-    DIFF_BASE="{{diff_base}}"
     if [ -z "$PREFIX" ]; then
         PREFIX="$(git rev-parse --abbrev-ref HEAD)"
     fi
-    ARGS="--prefix $PREFIX"
-    if [ -n "$DIFF_BASE" ]; then
-        ARGS="$ARGS --diff-base $DIFF_BASE"
-    fi
-    bash scripts/sync-media.sh $ARGS
+    bash scripts/sync-media.sh --prefix "$PREFIX"
 
 [doc("Delete a branch's media from R2")]
 [arg('branch', long, help="branch name prefix to delete")]

--- a/just/scripts/cleanup-r2-prefix.sh
+++ b/just/scripts/cleanup-r2-prefix.sh
@@ -9,6 +9,11 @@ usage() {
   echo ""
   echo "Deletes all objects under {prefix}/ in the R2 bucket."
   echo "Example: $0 --prefix v-2026"
+  echo ""
+  echo "Required env vars:"
+  echo "  CLOUDFLARE_ACCOUNT_ID   Cloudflare account ID (used to build R2 S3 endpoint)"
+  echo "  AWS_ACCESS_KEY_ID       R2 S3 API access key"
+  echo "  AWS_SECRET_ACCESS_KEY   R2 S3 API secret key"
   exit 1
 }
 
@@ -24,39 +29,23 @@ if [ -z "$PREFIX" ]; then
   usage
 fi
 
+if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+  echo "ERROR: CLOUDFLARE_ACCOUNT_ID is not set"
+  exit 1
+fi
+
 # Safety: never delete the main prefix via this script
 if [ "$PREFIX" = "main" ]; then
   echo "ERROR: Refusing to delete the main prefix. This script is for cleaning up branch prefixes."
   exit 1
 fi
 
+R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
 echo "Cleaning up R2 prefix: $PREFIX/ in bucket $BUCKET"
 echo ""
 
-# List all objects under the prefix and delete them one by one
-# wrangler r2 object list outputs JSON; extract keys with a simple parser
-KEYS=$(npx wrangler r2 object list "$BUCKET" --prefix "$PREFIX/" --remote 2>&1 \
-  | grep -oE '"key"\s*:\s*"[^"]*"' \
-  | sed 's/"key"[[:space:]]*:[[:space:]]*"//;s/"$//' || true)
-
-if [ -z "$KEYS" ]; then
-  echo "No objects found under prefix: $PREFIX/"
-  exit 0
-fi
-
-COUNT=0
-TOTAL=$(echo "$KEYS" | wc -l | tr -d ' ')
-echo "Found $TOTAL objects to delete"
-
-echo "$KEYS" | while IFS= read -r key; do
-  COUNT=$((COUNT + 1))
-  printf "  [%d/%d] Deleting %s " "$COUNT" "$TOTAL" "$key"
-  if npx wrangler r2 object delete "$BUCKET/$key" --remote > /dev/null 2>&1; then
-    echo "ok"
-  else
-    echo "FAILED"
-  fi
-done
+aws s3 rm "s3://$BUCKET/$PREFIX/" --recursive --endpoint-url "$R2_ENDPOINT"
 
 echo ""
 echo "Cleanup complete"

--- a/just/scripts/sync-media.sh
+++ b/just/scripts/sync-media.sh
@@ -5,27 +5,31 @@ BUCKET="thalida-media"
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 APP_DIR="$ROOT_DIR/app"
 PREFIX=""
-DIFF_BASE=""
 
-MEDIA_EXTENSIONS="jpg|jpeg|png|gif|webp|svg|mov|mp4"
+MEDIA_INCLUDES=(
+  --include "*.jpg" --include "*.jpeg" --include "*.png"
+  --include "*.gif" --include "*.webp" --include "*.svg"
+  --include "*.mov" --include "*.mp4"
+)
 
 usage() {
-  echo "Usage: $0 --prefix <branch-name> [--diff-base <commit-sha>]"
+  echo "Usage: $0 --prefix <branch-name>"
   echo ""
   echo "Syncs media files to R2 under {prefix}/content/..."
   echo ""
   echo "Options:"
-  echo "  --prefix      Required. Branch name used as R2 key prefix."
-  echo "  --diff-base   Optional. Commit SHA to diff against HEAD."
-  echo "                Only changed media files are uploaded."
-  echo "                Omit for a full sync of all media."
+  echo "  --prefix   Required. Branch name used as R2 key prefix."
+  echo ""
+  echo "Required env vars:"
+  echo "  CLOUDFLARE_ACCOUNT_ID   Cloudflare account ID (used to build R2 S3 endpoint)"
+  echo "  AWS_ACCESS_KEY_ID       R2 S3 API access key"
+  echo "  AWS_SECRET_ACCESS_KEY   R2 S3 API secret key"
   exit 1
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --prefix)    PREFIX="$2"; shift 2 ;;
-    --diff-base) DIFF_BASE="$2"; shift 2 ;;
+    --prefix) PREFIX="$2"; shift 2 ;;
     *) usage ;;
   esac
 done
@@ -35,124 +39,44 @@ if [ -z "$PREFIX" ]; then
   usage
 fi
 
-get_content_type() {
-  case "$(echo "${1##*.}" | tr '[:upper:]' '[:lower:]')" in
-    jpg|jpeg) echo "image/jpeg" ;;
-    png)      echo "image/png" ;;
-    gif)      echo "image/gif" ;;
-    webp)     echo "image/webp" ;;
-    svg)      echo "image/svg+xml" ;;
-    mp4)      echo "video/mp4" ;;
-    mov)      echo "video/quicktime" ;;
-    *)        echo "application/octet-stream" ;;
-  esac
-}
-
-upload() {
-  local file="$1"
-  local key="$2"
-  local ct
-  ct="$(get_content_type "$file")"
-  npx wrangler r2 object put "$BUCKET/$key" --file="$file" --content-type="$ct" --remote 2>&1 | tail -1
-}
-
-is_media_file() {
-  echo "$1" | grep -qiE "\.($MEDIA_EXTENSIONS)$"
-}
-
-# ── Collect files to sync ──────────────────────────────────────────
-
-FILES=()
-
-if [ -n "$DIFF_BASE" ]; then
-  echo "Syncing media to R2 bucket: $BUCKET (prefix: $PREFIX, incremental from $DIFF_BASE)"
-  echo ""
-
-  CHANGED=$(git diff --name-only --diff-filter=ACMR "$DIFF_BASE"..HEAD 2>/dev/null || true)
-
-  if [ -z "$CHANGED" ]; then
-    echo "No files changed. Nothing to sync."
-    exit 0
-  fi
-
-  while IFS= read -r relpath; do
-    # Media in app/src/content/
-    if [[ "$relpath" == app/src/content/* ]] && is_media_file "$relpath"; then
-      file="$ROOT_DIR/$relpath"
-      if [ -f "$file" ]; then
-        SRC_PREFIX="$APP_DIR/src/"
-        key="$PREFIX/${file#$SRC_PREFIX}"
-        FILES+=("$file|$key")
-      fi
-    fi
-
-    # Media in app/public/content/
-    if [[ "$relpath" == app/public/content/* ]]; then
-      file="$ROOT_DIR/$relpath"
-      if [ -f "$file" ]; then
-        PUB_PREFIX="$APP_DIR/public/"
-        key="$PREFIX/${file#$PUB_PREFIX}"
-        FILES+=("$file|$key")
-      fi
-    fi
-  done <<< "$CHANGED"
-
-  if [ ${#FILES[@]} -eq 0 ]; then
-    echo "No media files changed. Nothing to sync."
-    exit 0
-  fi
-else
-  echo "Syncing media to R2 bucket: $BUCKET (prefix: $PREFIX, full sync)"
-  echo ""
-
-  # Images from app/src/content/
-  if [ -d "$APP_DIR/src/content" ]; then
-    SRC_PREFIX="$APP_DIR/src/"
-    while IFS= read -r -d '' file; do
-      key="$PREFIX/${file#$SRC_PREFIX}"
-      FILES+=("$file|$key")
-    done < <(find "$APP_DIR/src/content" -type f \( \
-      -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o \
-      -iname "*.gif" -o -iname "*.webp" -o -iname "*.svg" -o \
-      -iname "*.mov" -o -iname "*.mp4" \
-    \) -print0)
-  fi
-
-  # Videos and large media from app/public/content/
-  if [ -d "$APP_DIR/public/content" ]; then
-    PUB_PREFIX="$APP_DIR/public/"
-    while IFS= read -r -d '' file; do
-      key="$PREFIX/${file#$PUB_PREFIX}"
-      FILES+=("$file|$key")
-    done < <(find "$APP_DIR/public/content" -type f -print0)
-  fi
-fi
-
-# ── Upload ─────────────────────────────────────────────────────────
-
-TOTAL=${#FILES[@]}
-echo "Found $TOTAL media file(s) to sync"
-echo ""
-
-COUNT=0
-ERRORS=0
-
-for entry in "${FILES[@]}"; do
-  file="${entry%%|*}"
-  key="${entry#*|}"
-  COUNT=$((COUNT + 1))
-  printf "  [%d/%d] %s " "$COUNT" "$TOTAL" "$key"
-  if upload "$file" "$key"; then
-    echo "ok"
-  else
-    echo "FAILED"
-    ERRORS=$((ERRORS + 1))
-  fi
-done
-
-echo ""
-echo "Sync complete: $((COUNT - ERRORS))/$COUNT files uploaded"
-if [ "$ERRORS" -gt 0 ]; then
-  echo "WARNING: $ERRORS files failed to upload"
+if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+  echo "ERROR: CLOUDFLARE_ACCOUNT_ID is not set"
   exit 1
 fi
+
+R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+DEST="s3://$BUCKET/$PREFIX"
+
+echo "Syncing media to R2 bucket: $BUCKET (prefix: $PREFIX)"
+echo ""
+
+ERRORS=0
+
+# Media from app/src/content/ (only media extensions)
+if [ -d "$APP_DIR/src/content" ]; then
+  echo "Syncing app/src/content/ (media files only)..."
+  if ! aws s3 sync "$APP_DIR/src/content/" "$DEST/content/" \
+    --endpoint-url "$R2_ENDPOINT" \
+    --exclude "*" \
+    "${MEDIA_INCLUDES[@]}"; then
+    ERRORS=$((ERRORS + 1))
+  fi
+  echo ""
+fi
+
+# All files from app/public/content/
+if [ -d "$APP_DIR/public/content" ]; then
+  echo "Syncing app/public/content/ (all files)..."
+  if ! aws s3 sync "$APP_DIR/public/content/" "$DEST/content/" \
+    --endpoint-url "$R2_ENDPOINT"; then
+    ERRORS=$((ERRORS + 1))
+  fi
+  echo ""
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "WARNING: $ERRORS sync operations failed"
+  exit 1
+fi
+
+echo "Sync complete"


### PR DESCRIPTION
wrangler v4 removed `r2 object list`, breaking the cleanup script silently. Rewrote both sync and cleanup scripts to use `aws s3 sync`/`aws s3 rm` with R2's S3-compatible endpoint. Removes wrangler and node dependencies from both CI jobs.