### PR TITLE
feat(chat): admin commands, moderation, and identity rearchitecture

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,4 +27,4 @@
 - [ ] copy favicon and setup metadata -- copy from v-2025
 - [x] change # of viewers into # of users (?) # of
 - [ ] fix link card styling
-- [ ] chatting as is misaligned from input by 2 px
+- [x] chatting as is misaligned from input by 2 px

--- a/TODO.md
+++ b/TODO.md
@@ -20,10 +20,11 @@
 - [x] add extended md w/ custom items like callouts
 - [x] homepage projects
 - [x] Fix chat row styling: username @ path on left, truncate
-  middle of long paths
+      middle of long paths
 - [ ] improve homepage history
 - [x] add ability to remove chat messages if admin or manually flag if admin
 - [x] add an admin only /help that shows admin options
 - [ ] copy favicon and setup metadata -- copy from v-2025
-- [ ] change # of viewers into # of users (?) # of
+- [x] change # of viewers into # of users (?) # of
 - [ ] fix link card styling
+- [ ] chatting as is misaligned from input by 2 px

--- a/TODO.md
+++ b/TODO.md
@@ -19,3 +19,11 @@
 - [x] fix "tip" in md
 - [x] add extended md w/ custom items like callouts
 - [x] homepage projects
+- [x] Fix chat row styling: username @ path on left, truncate
+  middle of long paths
+- [ ] improve homepage history
+- [x] add ability to remove chat messages if admin or manually flag if admin
+- [x] add an admin only /help that shows admin options
+- [ ] copy favicon and setup metadata -- copy from v-2025
+- [ ] change # of viewers into # of users (?) # of
+- [ ] fix link card styling

--- a/api/eslint.config.mjs
+++ b/api/eslint.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ["*.mjs", "vitest.config.ts"],
+          allowDefaultProject: ["*.mjs", "vitest.config.ts", "src/__tests__/*.ts"],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -3655,6 +3655,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/api/src/__tests__/chat-room.test.ts
+++ b/api/src/__tests__/chat-room.test.ts
@@ -157,21 +157,20 @@ describe("ChatRoom Durable Object", () => {
       ws2.close();
     });
 
-    it("message buffer caps at 50", async () => {
-      const { ws } = await connectAndJoin("spammer");
+    it("messages persist to durable storage", async () => {
+      const { ws } = await connectAndJoin("persister");
 
-      for (let i = 0; i < 55; i++) {
-        send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: `msg-${i}` } });
-      }
+      send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "persistent msg" } });
       await flush();
 
-      // Connect a new user and check history
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("reader");
+      // Connect a new user and check history includes the persisted message
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("checker");
       const history = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.HISTORY);
       expect(history).toBeDefined();
       if (history && history.type === SERVER_MESSAGE_TYPE.HISTORY) {
-        expect(history.messages.length).toBeLessThanOrEqual(50);
-        expect(history.messages[0].text).not.toBe("msg-0");
+        expect(history.messages.length).toBeGreaterThanOrEqual(1);
+        const found = history.messages.find((m: { text: string }) => m.text === "persistent msg");
+        expect(found).toBeDefined();
       }
 
       ws.close();

--- a/api/src/__tests__/chat-room.test.ts
+++ b/api/src/__tests__/chat-room.test.ts
@@ -447,6 +447,45 @@ describe("ChatRoom Durable Object", () => {
       ws2.close();
     });
 
+    it("admin /blocked returns list of blocked entries", async () => {
+      // First, create a blocked user by having admin flag someone
+      const { ws: userWs, msgs: _userMsgs } = await connectAndJoin("troublemaker", { ip: "10.0.0.77" });
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+        ip: "10.0.0.1",
+      });
+
+      send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "bad stuff" } });
+      await flush();
+
+      const chatMsg = adminMsgs.find((m): m is ChatMessage => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      const msgId = chatMsg?.id;
+
+      send(adminWs, { type: "flag", data: { id: msgId } });
+      await flush();
+
+      adminMsgs.length = 0;
+
+      // Now ask for the blocked list
+      send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/blocked" } });
+      await flush();
+
+      const list = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.BLOCKED_LIST);
+      expect(list).toBeDefined();
+      if (list && list.type === SERVER_MESSAGE_TYPE.BLOCKED_LIST) {
+        expect(list.entries.length).toBeGreaterThanOrEqual(1);
+        const entry = list.entries.find((e) => e.ip === "10.0.0.77");
+        expect(entry).toBeDefined();
+        if (entry) {
+          expect(entry.username).toBe("troublemaker");
+          expect(entry.blockedAt).toBeGreaterThan(0);
+        }
+      }
+
+      adminWs.close();
+      userWs.close();
+    });
+
     it("admin unknown /command sends as regular chat message", async () => {
       const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
         token: "test-admin-secret",

--- a/api/src/__tests__/chat-room.test.ts
+++ b/api/src/__tests__/chat-room.test.ts
@@ -367,6 +367,110 @@ describe("ChatRoom Durable Object", () => {
     });
   });
 
+  // ── Admin Commands ─────────────────────────────────────────────
+
+  describe("admin commands", () => {
+    it("admin /help returns help message with command list", async () => {
+      const { ws, msgs } = await connectAndJoin("thalida", { token: "test-admin-secret" });
+      msgs.length = 0;
+
+      send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/help" } });
+      await flush();
+
+      const help = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.HELP);
+      expect(help).toBeDefined();
+      if (help && help.type === SERVER_MESSAGE_TYPE.HELP) {
+        expect(help.commands.length).toBeGreaterThanOrEqual(2);
+        const names = help.commands.map((c) => c.name);
+        expect(names).toContain("help");
+        expect(names).toContain("unblock");
+      }
+
+      ws.close();
+    });
+
+    it("/help is not broadcast to other users", async () => {
+      const { ws: adminWs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+        ip: "10.0.0.1",
+      });
+      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("viewer", { ip: "10.0.0.2" });
+      otherMsgs.length = 0;
+
+      send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/help" } });
+      await flush();
+
+      const anyMsg = otherMsgs.filter(
+        (m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE || m.type === SERVER_MESSAGE_TYPE.HELP,
+      );
+      expect(anyMsg).toHaveLength(0);
+
+      adminWs.close();
+      otherWs.close();
+    });
+
+    it("non-admin /help sends as regular chat message", async () => {
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("regular");
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("observer");
+
+      msgs1.length = 0;
+      msgs2.length = 0;
+
+      send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/help" } });
+      await flush();
+
+      const msg = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      expect(msg).toMatchObject({ type: SERVER_MESSAGE_TYPE.MESSAGE, username: "regular", text: "/help" });
+
+      ws1.close();
+      ws2.close();
+    });
+
+    it("non-admin /unblock sends as regular chat message", async () => {
+      const { ws, msgs } = await connectAndJoin("regular-user", { ip: "10.0.0.2" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("watcher", { ip: "10.0.0.3" });
+
+      msgs.length = 0;
+      msgs2.length = 0;
+
+      send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/unblock 10.0.0.50" } });
+      await flush();
+
+      const msg = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      expect(msg).toMatchObject({
+        type: SERVER_MESSAGE_TYPE.MESSAGE,
+        username: "regular-user",
+        text: "/unblock 10.0.0.50",
+      });
+
+      ws.close();
+      ws2.close();
+    });
+
+    it("admin unknown /command sends as regular chat message", async () => {
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+      });
+      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("viewer");
+
+      adminMsgs.length = 0;
+      otherMsgs.length = 0;
+
+      send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/nonexistent" } });
+      await flush();
+
+      const msg = otherMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      expect(msg).toMatchObject({
+        type: SERVER_MESSAGE_TYPE.MESSAGE,
+        username: "thalida",
+        text: "/nonexistent",
+      });
+
+      adminWs.close();
+      otherWs.close();
+    });
+  });
+
   // ── Failure / Error States ───────────────────────────────────────
 
   describe("failure and error states", () => {

--- a/api/src/__tests__/chat-room.test.ts
+++ b/api/src/__tests__/chat-room.test.ts
@@ -549,6 +549,91 @@ describe("ChatRoom Durable Object", () => {
     });
   });
 
+  // ── Admin Flag ─────────────────────────────────────────────────
+
+  describe("admin flag", () => {
+    it("admin can flag a user, which blocks their IP and responds with FLAGGED", async () => {
+      const { ws: userWs, msgs: userMsgs } = await connectAndJoin("bad-user", { ip: "10.0.0.99" });
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+        ip: "10.0.0.1",
+      });
+
+      userMsgs.length = 0;
+      adminMsgs.length = 0;
+
+      send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "offensive content" } });
+      await flush();
+
+      const chatMsg = adminMsgs.find((m): m is ChatMessage => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      const msgId = chatMsg?.id;
+
+      adminMsgs.length = 0;
+      userMsgs.length = 0;
+
+      send(adminWs, { type: "flag", data: { id: msgId } });
+      await flush();
+
+      const flagged = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.FLAGGED);
+      expect(flagged).toMatchObject({
+        type: SERVER_MESSAGE_TYPE.FLAGGED,
+        username: "bad-user",
+        ip: "10.0.0.99",
+        messageId: msgId,
+      });
+
+      const blocked = userMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.BLOCKED);
+      expect(blocked).toBeDefined();
+
+      adminWs.close();
+      userWs.close();
+    });
+
+    it("non-admin flag request is silently ignored", async () => {
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("target", { ip: "10.0.0.10" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("hacker", { ip: "10.0.0.11" });
+
+      msgs1.length = 0;
+      msgs2.length = 0;
+
+      send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "normal message" } });
+      await flush();
+
+      const chatMsg = msgs2.find((m): m is ChatMessage => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      const msgId = chatMsg?.id;
+
+      msgs1.length = 0;
+      msgs2.length = 0;
+
+      send(ws2, { type: "flag", data: { id: msgId } });
+      await flush();
+
+      const flagged = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.FLAGGED);
+      expect(flagged).toBeUndefined();
+      const blocked = msgs1.find((m) => m.type === SERVER_MESSAGE_TYPE.BLOCKED);
+      expect(blocked).toBeUndefined();
+
+      ws1.close();
+      ws2.close();
+    });
+
+    it("flagging nonexistent message ID is silently ignored", async () => {
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+      });
+
+      adminMsgs.length = 0;
+
+      send(adminWs, { type: "flag", data: { id: "nonexistent-id" } });
+      await flush();
+
+      const flagged = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.FLAGGED);
+      expect(flagged).toBeUndefined();
+
+      adminWs.close();
+    });
+  });
+
   // ── Failure / Error States ───────────────────────────────────────
 
   describe("failure and error states", () => {

--- a/api/src/__tests__/chat-room.test.ts
+++ b/api/src/__tests__/chat-room.test.ts
@@ -547,6 +547,48 @@ describe("ChatRoom Durable Object", () => {
 
       adminWs.close();
     });
+
+    it("admin can delete all messages from a username", async () => {
+      const { ws: userWs } = await connectAndJoin("bulk-poster");
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+      });
+
+      send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "spam 1" } });
+      send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "spam 2" } });
+      send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "spam 3" } });
+      await flush();
+
+      adminMsgs.length = 0;
+
+      send(adminWs, { type: "delete_by_user", data: { username: "bulk-poster" } });
+      await flush();
+
+      const removes = adminMsgs.filter((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+      expect(removes).toHaveLength(3);
+
+      userWs.close();
+      adminWs.close();
+    });
+
+    it("non-admin delete_by_user is silently ignored", async () => {
+      const { ws: ws1 } = await connectAndJoin("poster");
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("hacker");
+
+      send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "keep this" } });
+      await flush();
+
+      msgs2.length = 0;
+
+      send(ws2, { type: "delete_by_user", data: { username: "poster" } });
+      await flush();
+
+      const removes = msgs2.filter((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+      expect(removes).toHaveLength(0);
+
+      ws1.close();
+      ws2.close();
+    });
   });
 
   // ── Admin Flag ─────────────────────────────────────────────────

--- a/api/src/__tests__/chat-room.test.ts
+++ b/api/src/__tests__/chat-room.test.ts
@@ -1,6 +1,6 @@
 import { SELF } from "cloudflare:test";
 import { describe, it, expect } from "vitest";
-import type { ServerMessage } from "../types";
+import type { ChatMessage, ServerMessage } from "../types";
 import { CLIENT_MESSAGE_TYPE, SERVER_ERROR_CODE, SERVER_MESSAGE_TYPE } from "../types";
 
 // ── helpers ──────────────────────────────────────────────────────────
@@ -468,6 +468,84 @@ describe("ChatRoom Durable Object", () => {
 
       adminWs.close();
       otherWs.close();
+    });
+  });
+
+  // ── Admin Delete ────────────────────────────────────────────────
+
+  describe("admin delete", () => {
+    it("admin can delete a message by ID", async () => {
+      const { ws: userWs, msgs: userMsgs } = await connectAndJoin("chatter");
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+      });
+
+      userMsgs.length = 0;
+      adminMsgs.length = 0;
+
+      send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "delete me" } });
+      await flush();
+
+      const chatMsg = adminMsgs.find((m): m is ChatMessage => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      expect(chatMsg).toBeDefined();
+      const msgId = chatMsg?.id;
+      expect(msgId).toBeDefined();
+
+      adminMsgs.length = 0;
+      userMsgs.length = 0;
+
+      send(adminWs, { type: "delete", data: { id: msgId } });
+      await flush();
+
+      const remove1 = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+      const remove2 = userMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+      expect(remove1).toMatchObject({ type: SERVER_MESSAGE_TYPE.REMOVE, id: msgId });
+      expect(remove2).toMatchObject({ type: SERVER_MESSAGE_TYPE.REMOVE, id: msgId });
+
+      userWs.close();
+      adminWs.close();
+    });
+
+    it("non-admin delete request is silently ignored", async () => {
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("sender");
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("hacker");
+
+      msgs1.length = 0;
+      msgs2.length = 0;
+
+      send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "stay here" } });
+      await flush();
+
+      const chatMsg = msgs2.find((m): m is ChatMessage => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      const msgId = chatMsg?.id;
+
+      msgs1.length = 0;
+      msgs2.length = 0;
+
+      send(ws2, { type: "delete", data: { id: msgId } });
+      await flush();
+
+      const remove = msgs1.find((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+      expect(remove).toBeUndefined();
+
+      ws1.close();
+      ws2.close();
+    });
+
+    it("delete of nonexistent message ID is silently ignored", async () => {
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+      });
+
+      adminMsgs.length = 0;
+
+      send(adminWs, { type: "delete", data: { id: "nonexistent-id" } });
+      await flush();
+
+      const remove = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+      expect(remove).toBeUndefined();
+
+      adminWs.close();
     });
   });
 

--- a/api/src/__tests__/chat-room.test.ts
+++ b/api/src/__tests__/chat-room.test.ts
@@ -31,19 +31,40 @@ async function flush(): Promise<void> {
   await new Promise((r) => setTimeout(r, 200));
 }
 
-async function connectAndJoin(
-  username: string,
-  options?: { token?: string; clientId?: string },
-): Promise<{ ws: WebSocket; msgs: ServerMessage[] }> {
+async function connectAndJoin(options?: {
+  token?: string;
+  clientId?: string;
+  username?: string;
+}): Promise<{ ws: WebSocket; msgs: ServerMessage[]; username: string }> {
   const ws = await openWs();
   const msgs = collect(ws);
   await flush();
 
-  const data: Record<string, unknown> = { username, clientId: options?.clientId ?? crypto.randomUUID() };
+  const data: Record<string, unknown> = { clientId: options?.clientId ?? crypto.randomUUID() };
   if (options?.token) data.token = options.token;
   send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data });
   await flush();
-  return { ws, msgs };
+
+  // Extract the server-assigned username from JOINED response
+  const joined = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
+  let username = "";
+  if (joined && "username" in joined) {
+    username = (joined as { username: string }).username;
+  }
+
+  // If a specific username was requested (and we're not admin), send a rename
+  if (options?.username && username !== options.username) {
+    send(ws, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: options.username } });
+    await flush();
+    // The JOINED response from rename confirms the new name
+    const joinedIdx = joined ? msgs.indexOf(joined) : -1;
+    const renameJoined = msgs.find((m, i) => m.type === SERVER_MESSAGE_TYPE.JOINED && i > joinedIdx);
+    if (renameJoined && "username" in renameJoined) {
+      username = (renameJoined as { username: string }).username;
+    }
+  }
+
+  return { ws, msgs, username };
 }
 
 // ── tests ────────────────────────────────────────────────────────────
@@ -63,11 +84,12 @@ describe("ChatRoom Durable Object", () => {
       ws.close();
     });
 
-    it("join with valid username returns joined + history + status", async () => {
-      const { ws, msgs } = await connectAndJoin("red-fox");
+    it("join returns server-assigned username + history + status", async () => {
+      const { ws, msgs, username } = await connectAndJoin();
 
       const joined = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
-      expect(joined).toMatchObject({ type: SERVER_MESSAGE_TYPE.JOINED, isOwner: false, username: "red-fox" });
+      expect(joined).toMatchObject({ type: SERVER_MESSAGE_TYPE.JOINED, isOwner: false });
+      expect(username.length).toBeGreaterThanOrEqual(2);
 
       const history = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.HISTORY);
       expect(history).toBeDefined();
@@ -82,8 +104,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("message is broadcast to all connected users", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("alpha");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("beta");
+      const { ws: ws1, msgs: msgs1, username: user1 } = await connectAndJoin({ username: "alpha" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "beta" });
 
       msgs1.length = 0;
       msgs2.length = 0;
@@ -93,16 +115,16 @@ describe("ChatRoom Durable Object", () => {
 
       const msg1 = msgs1.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
       const msg2 = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
-      expect(msg1).toMatchObject({ type: SERVER_MESSAGE_TYPE.MESSAGE, username: "alpha", text: "hello from alpha" });
-      expect(msg2).toMatchObject({ type: SERVER_MESSAGE_TYPE.MESSAGE, username: "alpha", text: "hello from alpha" });
+      expect(msg1).toMatchObject({ type: SERVER_MESSAGE_TYPE.MESSAGE, username: user1, text: "hello from alpha" });
+      expect(msg2).toMatchObject({ type: SERVER_MESSAGE_TYPE.MESSAGE, username: user1, text: "hello from alpha" });
 
       ws1.close();
       ws2.close();
     });
 
     it("two users join and both see correct user count", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("user-one");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("user-two");
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin({ username: "user-one" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "user-two" });
 
       const status1 = [...msgs1].reverse().find((m) => m.type === SERVER_MESSAGE_TYPE.STATUS);
       const status2 = [...msgs2].reverse().find((m) => m.type === SERVER_MESSAGE_TYPE.STATUS);
@@ -115,7 +137,7 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("owner joins with valid ADMIN_SECRET token and receives joined message", async () => {
-      const { ws, msgs } = await connectAndJoin("anything", { token: "test-admin-secret" });
+      const { ws, msgs } = await connectAndJoin({ token: "test-admin-secret" });
 
       const joined = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
       expect(joined).toMatchObject({ type: SERVER_MESSAGE_TYPE.JOINED, isOwner: true, username: "thalida" });
@@ -127,7 +149,7 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("owner username is forced to 'thalida' regardless of input", async () => {
-      const { ws, msgs } = await connectAndJoin("some-other-name", { token: "test-admin-secret" });
+      const { ws, msgs } = await connectAndJoin({ token: "test-admin-secret" });
 
       const joined = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
       expect(joined).toMatchObject({ type: SERVER_MESSAGE_TYPE.JOINED, isOwner: true, username: "thalida" });
@@ -144,8 +166,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("multiple owner sessions can share the 'thalida' username", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("thalida", { token: "test-admin-secret" });
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("thalida", { token: "test-admin-secret" });
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin({ token: "test-admin-secret" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ token: "test-admin-secret" });
 
       const joined1 = msgs1.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
       expect(joined1).toMatchObject({ type: SERVER_MESSAGE_TYPE.JOINED, isOwner: true, username: "thalida" });
@@ -158,13 +180,13 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("messages persist to durable storage", async () => {
-      const { ws } = await connectAndJoin("persister");
+      const { ws } = await connectAndJoin({ username: "persister" });
 
       send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "persistent msg" } });
       await flush();
 
       // Connect a new user and check history includes the persisted message
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("checker");
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "checker" });
       const history = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.HISTORY);
       expect(history).toBeDefined();
       if (history && history.type === SERVER_MESSAGE_TYPE.HISTORY) {
@@ -178,8 +200,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("user disconnect decrements user count", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("stayer");
-      const { ws: ws2 } = await connectAndJoin("leaver");
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin({ username: "stayer" });
+      const { ws: ws2 } = await connectAndJoin({ username: "leaver" });
 
       msgs1.length = 0;
       ws2.close();
@@ -196,8 +218,8 @@ describe("ChatRoom Durable Object", () => {
 
   describe("security concerns", () => {
     it("XSS in message text is stored as-is (plain text, no mangling)", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("sender");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("receiver");
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin({ username: "sender" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "receiver" });
 
       msgs1.length = 0;
       msgs2.length = 0;
@@ -216,12 +238,11 @@ describe("ChatRoom Durable Object", () => {
       ws2.close();
     });
 
-    it("XSS in username is rejected by validation regex", async () => {
-      const ws = await openWs();
-      const msgs = collect(ws);
-      await flush();
+    it("XSS in username is rejected by validation regex via rename", async () => {
+      const { ws, msgs } = await connectAndJoin();
+      msgs.length = 0;
 
-      send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: '<img onerror=alert(1) src="x">' } });
+      send(ws, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: '<img onerror=alert(1) src="x">' } });
       await flush();
 
       const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
@@ -231,34 +252,28 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("invalid admin token does not grant owner status", async () => {
-      const ws = await openWs();
-      const _msgs = collect(ws);
+      // Join with wrong token - should still succeed but not be owner
+      const { ws, msgs } = await connectAndJoin({ token: "wrong-secret" });
+
+      const joined = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
+      expect(joined).toMatchObject({ type: SERVER_MESSAGE_TYPE.JOINED, isOwner: false });
+
+      // Should not be able to use reserved name "thalida" via rename
+      msgs.length = 0;
+      send(ws, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: "thalida" } });
       await flush();
 
-      send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "imposter", token: "wrong-secret" } });
-      await flush();
-
-      // Should not be able to use reserved name as non-owner
-      const ws2 = await openWs();
-      const msgs2 = collect(ws2);
-      await flush();
-
-      send(ws2, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "thalida", token: "wrong-secret" } });
-      await flush();
-
-      const error = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
+      const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
       expect(error).toMatchObject({ type: SERVER_MESSAGE_TYPE.ERROR, code: SERVER_ERROR_CODE.RESERVED_USERNAME });
 
       ws.close();
-      ws2.close();
     });
 
     it("empty string admin token is not treated as valid owner", async () => {
-      const ws = await openWs();
-      const msgs = collect(ws);
-      await flush();
+      const { ws, msgs } = await connectAndJoin({ token: "" });
+      msgs.length = 0;
 
-      send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "thalida", token: "" } });
+      send(ws, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: "thalida" } });
       await flush();
 
       const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
@@ -268,8 +283,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("message text is truncated at 500 characters", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("truncator");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("watcher");
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin({ username: "truncator" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "watcher" });
 
       msgs1.length = 0;
       msgs2.length = 0;
@@ -289,8 +304,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("blocked user receives blocked notice", async () => {
-      const { ws: sender, msgs: senderMsgs } = await connectAndJoin("bad-actor");
-      const { ws: other } = await connectAndJoin("bystander");
+      const { ws: sender, msgs: senderMsgs } = await connectAndJoin({ username: "bad-actor" });
+      const { ws: other } = await connectAndJoin({ username: "bystander" });
 
       // Simulate 3 warnings by sending moderation-flagged content
       // Since OPENAI_API_KEY is empty, moderation is skipped.
@@ -315,7 +330,7 @@ describe("ChatRoom Durable Object", () => {
 
   describe("Blocking", () => {
     it("admin can unblock a client via unblock message", async () => {
-      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin({
         token: "test-admin-secret",
       });
       adminMsgs.length = 0;
@@ -334,7 +349,7 @@ describe("ChatRoom Durable Object", () => {
 
   describe("admin commands", () => {
     it("admin /help returns help message with command list", async () => {
-      const { ws, msgs } = await connectAndJoin("thalida", { token: "test-admin-secret" });
+      const { ws, msgs } = await connectAndJoin({ token: "test-admin-secret" });
       msgs.length = 0;
 
       send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/help" } });
@@ -353,10 +368,10 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("/help is not broadcast to other users", async () => {
-      const { ws: adminWs } = await connectAndJoin("thalida", {
+      const { ws: adminWs } = await connectAndJoin({
         token: "test-admin-secret",
       });
-      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("viewer");
+      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin({ username: "viewer" });
       otherMsgs.length = 0;
 
       send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/help" } });
@@ -372,8 +387,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("non-admin /help sends as regular chat message", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("regular");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("observer");
+      const { ws: ws1, msgs: msgs1, username: user1 } = await connectAndJoin({ username: "regular" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "observer" });
 
       msgs1.length = 0;
       msgs2.length = 0;
@@ -382,7 +397,7 @@ describe("ChatRoom Durable Object", () => {
       await flush();
 
       const msg = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
-      expect(msg).toMatchObject({ type: SERVER_MESSAGE_TYPE.MESSAGE, username: "regular", text: "/help" });
+      expect(msg).toMatchObject({ type: SERVER_MESSAGE_TYPE.MESSAGE, username: user1, text: "/help" });
 
       ws1.close();
       ws2.close();
@@ -390,8 +405,12 @@ describe("ChatRoom Durable Object", () => {
 
     it("admin /blocked returns list of blocked entries", async () => {
       // First, create a blocked user by having admin flag someone
-      const { ws: userWs, msgs: _userMsgs } = await connectAndJoin("troublemaker");
-      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      const {
+        ws: userWs,
+        msgs: _userMsgs,
+        username: troublemakerName,
+      } = await connectAndJoin({ username: "troublemaker" });
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin({
         token: "test-admin-secret",
       });
 
@@ -414,7 +433,7 @@ describe("ChatRoom Durable Object", () => {
       expect(list).toBeDefined();
       if (list && list.type === SERVER_MESSAGE_TYPE.BLOCKED_LIST) {
         expect(list.entries.length).toBeGreaterThanOrEqual(1);
-        const entry = list.entries.find((e) => e.username === "troublemaker");
+        const entry = list.entries.find((e) => e.username === troublemakerName);
         expect(entry).toBeDefined();
         if (entry) {
           expect(entry.clientId).toBeDefined();
@@ -427,10 +446,10 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("admin unknown /command sends as regular chat message", async () => {
-      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin({
         token: "test-admin-secret",
       });
-      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("cmd-viewer");
+      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin({ username: "cmd-viewer" });
 
       adminMsgs.length = 0;
       otherMsgs.length = 0;
@@ -453,8 +472,8 @@ describe("ChatRoom Durable Object", () => {
 
   describe("admin delete", () => {
     it("admin can delete a message by ID", async () => {
-      const { ws: userWs, msgs: userMsgs } = await connectAndJoin("chatter");
-      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      const { ws: userWs, msgs: userMsgs } = await connectAndJoin({ username: "chatter" });
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin({
         token: "test-admin-secret",
       });
 
@@ -485,8 +504,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("non-admin delete request is silently ignored", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("del-sender");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("del-hacker");
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin({ username: "del-sender" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "del-hacker" });
 
       msgs1.length = 0;
       msgs2.length = 0;
@@ -511,7 +530,7 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("delete of nonexistent message ID is silently ignored", async () => {
-      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin({
         token: "test-admin-secret",
       });
 
@@ -528,8 +547,8 @@ describe("ChatRoom Durable Object", () => {
 
     it("admin can delete all messages from a client", async () => {
       const cid = crypto.randomUUID();
-      const { ws: userWs } = await connectAndJoin("bulk-poster", { clientId: cid });
-      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      const { ws: userWs } = await connectAndJoin({ username: "bulk-poster", clientId: cid });
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin({
         token: "test-admin-secret",
       });
 
@@ -551,8 +570,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("non-admin delete_by_user is silently ignored", async () => {
-      const { ws: ws1 } = await connectAndJoin("dbu-poster");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("dbu-hacker");
+      const { ws: ws1 } = await connectAndJoin({ username: "dbu-poster" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "dbu-hacker" });
 
       send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "keep this" } });
       await flush();
@@ -574,8 +593,8 @@ describe("ChatRoom Durable Object", () => {
 
   describe("admin flag", () => {
     it("admin can flag a user, which blocks their IP and responds with FLAGGED", async () => {
-      const { ws: userWs, msgs: userMsgs } = await connectAndJoin("bad-user");
-      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      const { ws: userWs, msgs: userMsgs, username: badUserName } = await connectAndJoin({ username: "bad-user" });
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin({
         token: "test-admin-secret",
       });
 
@@ -597,7 +616,7 @@ describe("ChatRoom Durable Object", () => {
       const flagged = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.FLAGGED);
       expect(flagged).toMatchObject({
         type: SERVER_MESSAGE_TYPE.FLAGGED,
-        username: "bad-user",
+        username: badUserName,
         clientId: expect.any(String),
         messageId: msgId,
       });
@@ -610,8 +629,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("non-admin flag request is silently ignored", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("flag-target");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("flag-hacker");
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin({ username: "flag-target" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "flag-hacker" });
 
       msgs1.length = 0;
       msgs2.length = 0;
@@ -638,7 +657,7 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("flagging nonexistent message ID is silently ignored", async () => {
-      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin({
         token: "test-admin-secret",
       });
 
@@ -657,26 +676,11 @@ describe("ChatRoom Durable Object", () => {
   // ── Failure / Error States ───────────────────────────────────────
 
   describe("failure and error states", () => {
-    it("reserved word 'thalida' in username returns error without admin token", async () => {
-      const ws = await openWs();
-      const msgs = collect(ws);
-      await flush();
+    it("reserved word 'thalida' in username returns error via rename", async () => {
+      const { ws, msgs } = await connectAndJoin();
+      msgs.length = 0;
 
-      send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "thalida" } });
-      await flush();
-
-      const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
-      expect(error).toMatchObject({ type: SERVER_MESSAGE_TYPE.ERROR, code: SERVER_ERROR_CODE.RESERVED_USERNAME });
-
-      ws.close();
-    });
-
-    it("username containing admin name as substring returns error", async () => {
-      const ws = await openWs();
-      const msgs = collect(ws);
-      await flush();
-
-      send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "thalida-fan" } });
+      send(ws, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: "thalida" } });
       await flush();
 
       const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
@@ -685,12 +689,24 @@ describe("ChatRoom Durable Object", () => {
       ws.close();
     });
 
-    it("username too short (1 char) returns invalid_username error", async () => {
-      const ws = await openWs();
-      const msgs = collect(ws);
+    it("username containing admin name as substring returns error via rename", async () => {
+      const { ws, msgs } = await connectAndJoin();
+      msgs.length = 0;
+
+      send(ws, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: "thalida-fan" } });
       await flush();
 
-      send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "x" } });
+      const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
+      expect(error).toMatchObject({ type: SERVER_MESSAGE_TYPE.ERROR, code: SERVER_ERROR_CODE.RESERVED_USERNAME });
+
+      ws.close();
+    });
+
+    it("username too short (1 char) returns invalid_username error via rename", async () => {
+      const { ws, msgs } = await connectAndJoin();
+      msgs.length = 0;
+
+      send(ws, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: "x" } });
       await flush();
 
       const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
@@ -699,26 +715,11 @@ describe("ChatRoom Durable Object", () => {
       ws.close();
     });
 
-    it("username with spaces returns invalid_username error", async () => {
-      const ws = await openWs();
-      const msgs = collect(ws);
-      await flush();
+    it("username with spaces returns invalid_username error via rename", async () => {
+      const { ws, msgs } = await connectAndJoin();
+      msgs.length = 0;
 
-      send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "has spaces" } });
-      await flush();
-
-      const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
-      expect(error).toMatchObject({ type: SERVER_MESSAGE_TYPE.ERROR, code: SERVER_ERROR_CODE.INVALID_USERNAME });
-
-      ws.close();
-    });
-
-    it("username with special characters returns invalid_username error", async () => {
-      const ws = await openWs();
-      const msgs = collect(ws);
-      await flush();
-
-      send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "user@#$!" } });
+      send(ws, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: "has spaces" } });
       await flush();
 
       const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
@@ -727,14 +728,26 @@ describe("ChatRoom Durable Object", () => {
       ws.close();
     });
 
-    it("duplicate username returns taken_username error", async () => {
-      const { ws: ws1 } = await connectAndJoin("unique-name");
+    it("username with special characters returns invalid_username error via rename", async () => {
+      const { ws, msgs } = await connectAndJoin();
+      msgs.length = 0;
 
-      const ws2 = await openWs();
-      const msgs2 = collect(ws2);
+      send(ws, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: "user@#$!" } });
       await flush();
 
-      send(ws2, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "unique-name" } });
+      const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
+      expect(error).toMatchObject({ type: SERVER_MESSAGE_TYPE.ERROR, code: SERVER_ERROR_CODE.INVALID_USERNAME });
+
+      ws.close();
+    });
+
+    it("duplicate username returns taken_username error via rename", async () => {
+      const { ws: ws1, username: takenName } = await connectAndJoin({ username: "unique-name" });
+
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin();
+      msgs2.length = 0;
+
+      send(ws2, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: takenName } });
       await flush();
 
       const error = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
@@ -745,8 +758,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("empty message text is silently dropped", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("silent");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("listener");
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin({ username: "silent" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "listener" });
 
       msgs1.length = 0;
       msgs2.length = 0;
@@ -767,7 +780,7 @@ describe("ChatRoom Durable Object", () => {
       const _msgs1 = collect(ws1);
       await flush();
 
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("spec-observer");
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "spec-observer" });
       msgs2.length = 0;
 
       send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "ghost message" } });
@@ -781,7 +794,7 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("malformed JSON returns error and keeps connection alive", async () => {
-      const { ws, msgs } = await connectAndJoin("robust-user");
+      const { ws, msgs } = await connectAndJoin({ username: "robust-user" });
       msgs.length = 0;
 
       ws.send("this is not json {{{");
@@ -804,10 +817,10 @@ describe("ChatRoom Durable Object", () => {
   // ── Rename ──────────────────────────────────────────────────────
 
   describe("rename", () => {
-    it("re-joining with new username broadcasts rename and updates history", async () => {
+    it("rename message broadcasts rename and updates history", async () => {
       const cid = crypto.randomUUID();
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("old-name", { clientId: cid });
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("rename-watcher");
+      const { ws: ws1, msgs: msgs1, username: oldName } = await connectAndJoin({ username: "old-name", clientId: cid });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ username: "rename-watcher" });
 
       send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "hello" } });
       await flush();
@@ -815,22 +828,22 @@ describe("ChatRoom Durable Object", () => {
       msgs1.length = 0;
       msgs2.length = 0;
 
-      send(ws1, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "new-name", clientId: cid } });
+      send(ws1, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: "new-name" } });
       await flush();
 
       const rename = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.RENAME);
       expect(rename).toMatchObject({
         type: SERVER_MESSAGE_TYPE.RENAME,
-        oldUsername: "old-name",
+        oldUsername: oldName,
         newUsername: "new-name",
       });
 
-      const { ws: ws3, msgs: msgs3 } = await connectAndJoin("late-joiner");
+      const { ws: ws3, msgs: msgs3 } = await connectAndJoin({ username: "late-joiner" });
       const history = msgs3.find((m) => m.type === SERVER_MESSAGE_TYPE.HISTORY);
       if (history && history.type === SERVER_MESSAGE_TYPE.HISTORY) {
         const fromRenamed = history.messages.filter((m) => m.username === "new-name");
         expect(fromRenamed.length).toBeGreaterThanOrEqual(1);
-        const fromOld = history.messages.filter((m) => m.username === "old-name");
+        const fromOld = history.messages.filter((m) => m.username === oldName);
         expect(fromOld).toHaveLength(0);
       }
 
@@ -841,8 +854,8 @@ describe("ChatRoom Durable Object", () => {
 
     it("flag works after user has renamed", async () => {
       const cid = crypto.randomUUID();
-      const { ws: userWs, msgs: userMsgs } = await connectAndJoin("original", { clientId: cid });
-      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      const { ws: userWs, msgs: userMsgs } = await connectAndJoin({ username: "original", clientId: cid });
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin({
         token: "test-admin-secret",
       });
 
@@ -852,7 +865,7 @@ describe("ChatRoom Durable Object", () => {
       const chatMsg = adminMsgs.find((m): m is ChatMessage => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
       const msgId = chatMsg?.id;
 
-      send(userWs, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "renamed", clientId: cid } });
+      send(userWs, { type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: "renamed" } });
       await flush();
 
       adminMsgs.length = 0;
@@ -869,6 +882,69 @@ describe("ChatRoom Durable Object", () => {
 
       adminWs.close();
       userWs.close();
+    });
+  });
+
+  // ── Server-Assigned Identity ───────────────────────────────────
+
+  describe("server-assigned identity", () => {
+    it("join without username assigns a random name", async () => {
+      const ws = await openWs();
+      const msgs = collect(ws);
+      await flush();
+
+      send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { clientId: crypto.randomUUID() } });
+      await flush();
+
+      const joined = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
+      expect(joined).toBeDefined();
+      if (joined && "username" in joined) {
+        expect((joined as { username: string }).username.length).toBeGreaterThanOrEqual(2);
+      }
+
+      ws.close();
+    });
+
+    it("reconnecting with same clientId returns same username", async () => {
+      const cid = crypto.randomUUID();
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin({ clientId: cid });
+      const firstJoined = msgs1.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
+      const firstUsername =
+        firstJoined && "username" in firstJoined ? (firstJoined as { username: string }).username : "";
+      ws1.close();
+      await flush();
+
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ clientId: cid });
+      const secondJoined = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
+      const secondUsername =
+        secondJoined && "username" in secondJoined ? (secondJoined as { username: string }).username : "";
+
+      expect(secondUsername).toBe(firstUsername);
+
+      ws2.close();
+    });
+
+    it("admin login does not change client mapping, logout restores original name", async () => {
+      const cid = crypto.randomUUID();
+
+      // First join as regular user
+      const { ws: ws1, username: originalName } = await connectAndJoin({ clientId: cid });
+      ws1.close();
+      await flush();
+
+      // Login as admin with same clientId
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin({ token: "test-admin-secret", clientId: cid });
+      const adminJoined = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
+      expect(adminJoined).toMatchObject({ username: "thalida", isOwner: true });
+      ws2.close();
+      await flush();
+
+      // Logout (reconnect without token)
+      const { ws: ws3, msgs: msgs3 } = await connectAndJoin({ clientId: cid });
+      const logoutJoined = msgs3.find((m) => m.type === SERVER_MESSAGE_TYPE.JOINED);
+      expect(logoutJoined).toMatchObject({ username: originalName, isOwner: false });
+
+      ws3.close();
     });
   });
 });

--- a/api/src/__tests__/chat-room.test.ts
+++ b/api/src/__tests__/chat-room.test.ts
@@ -5,9 +5,9 @@ import { CLIENT_MESSAGE_TYPE, SERVER_ERROR_CODE, SERVER_MESSAGE_TYPE } from "../
 
 // ── helpers ──────────────────────────────────────────────────────────
 
-async function openWs(ip = "127.0.0.1"): Promise<WebSocket> {
+async function openWs(): Promise<WebSocket> {
   const resp = await SELF.fetch("https://fake-host/ws", {
-    headers: { Upgrade: "websocket", "CF-Connecting-IP": ip },
+    headers: { Upgrade: "websocket" },
   });
   const ws = resp.webSocket;
   if (!ws) throw new Error("No WebSocket returned");
@@ -28,18 +28,18 @@ function send(ws: WebSocket, data: Record<string, unknown>): void {
 }
 
 async function flush(): Promise<void> {
-  await new Promise((r) => setTimeout(r, 50));
+  await new Promise((r) => setTimeout(r, 200));
 }
 
 async function connectAndJoin(
   username: string,
-  options?: { token?: string; ip?: string },
+  options?: { token?: string; clientId?: string },
 ): Promise<{ ws: WebSocket; msgs: ServerMessage[] }> {
-  const ws = await openWs(options?.ip);
+  const ws = await openWs();
   const msgs = collect(ws);
   await flush();
 
-  const data: Record<string, unknown> = { username };
+  const data: Record<string, unknown> = { username, clientId: options?.clientId ?? crypto.randomUUID() };
   if (options?.token) data.token = options.token;
   send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data });
   await flush();
@@ -312,21 +312,20 @@ describe("ChatRoom Durable Object", () => {
     });
   });
 
-  // ── IP Blocking ─────────────────────────────────────────────────
+  // ── Blocking ────────────────────────────────────────────────────
 
-  describe("IP blocking", () => {
-    it("admin can unblock an IP via unblock message", async () => {
+  describe("Blocking", () => {
+    it("admin can unblock a client via unblock message", async () => {
       const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
         token: "test-admin-secret",
-        ip: "10.0.0.1",
       });
       adminMsgs.length = 0;
 
-      send(adminWs, { type: CLIENT_MESSAGE_TYPE.UNBLOCK, data: { ip: "10.0.0.50" } });
+      send(adminWs, { type: CLIENT_MESSAGE_TYPE.UNBLOCK, data: { clientId: "some-client-id" } });
       await flush();
 
       const unblocked = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.UNBLOCKED);
-      expect(unblocked).toMatchObject({ type: SERVER_MESSAGE_TYPE.UNBLOCKED, ip: "10.0.0.50" });
+      expect(unblocked).toMatchObject({ type: SERVER_MESSAGE_TYPE.UNBLOCKED, clientId: "some-client-id" });
 
       adminWs.close();
     });
@@ -357,9 +356,8 @@ describe("ChatRoom Durable Object", () => {
     it("/help is not broadcast to other users", async () => {
       const { ws: adminWs } = await connectAndJoin("thalida", {
         token: "test-admin-secret",
-        ip: "10.0.0.1",
       });
-      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("viewer", { ip: "10.0.0.2" });
+      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("viewer");
       otherMsgs.length = 0;
 
       send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/help" } });
@@ -393,10 +391,9 @@ describe("ChatRoom Durable Object", () => {
 
     it("admin /blocked returns list of blocked entries", async () => {
       // First, create a blocked user by having admin flag someone
-      const { ws: userWs, msgs: _userMsgs } = await connectAndJoin("troublemaker", { ip: "10.0.0.77" });
+      const { ws: userWs, msgs: _userMsgs } = await connectAndJoin("troublemaker");
       const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
         token: "test-admin-secret",
-        ip: "10.0.0.1",
       });
 
       send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "bad stuff" } });
@@ -418,10 +415,10 @@ describe("ChatRoom Durable Object", () => {
       expect(list).toBeDefined();
       if (list && list.type === SERVER_MESSAGE_TYPE.BLOCKED_LIST) {
         expect(list.entries.length).toBeGreaterThanOrEqual(1);
-        const entry = list.entries.find((e) => e.ip === "10.0.0.77");
+        const entry = list.entries.find((e) => e.username === "troublemaker");
         expect(entry).toBeDefined();
         if (entry) {
-          expect(entry.username).toBe("troublemaker");
+          expect(entry.clientId).toBeDefined();
           expect(entry.blockedAt).toBeGreaterThan(0);
         }
       }
@@ -434,14 +431,13 @@ describe("ChatRoom Durable Object", () => {
       const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
         token: "test-admin-secret",
       });
-      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("viewer");
+      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("cmd-viewer");
 
       adminMsgs.length = 0;
       otherMsgs.length = 0;
 
       send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/nonexistent" } });
       await flush();
-
       const msg = otherMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
       expect(msg).toMatchObject({
         type: SERVER_MESSAGE_TYPE.MESSAGE,
@@ -490,8 +486,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("non-admin delete request is silently ignored", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("sender");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("hacker");
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("del-sender");
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("del-hacker");
 
       msgs1.length = 0;
       msgs2.length = 0;
@@ -531,8 +527,9 @@ describe("ChatRoom Durable Object", () => {
       adminWs.close();
     });
 
-    it("admin can delete all messages from a username", async () => {
-      const { ws: userWs } = await connectAndJoin("bulk-poster");
+    it("admin can delete all messages from a client", async () => {
+      const cid = crypto.randomUUID();
+      const { ws: userWs } = await connectAndJoin("bulk-poster", { clientId: cid });
       const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
         token: "test-admin-secret",
       });
@@ -544,7 +541,7 @@ describe("ChatRoom Durable Object", () => {
 
       adminMsgs.length = 0;
 
-      send(adminWs, { type: "delete_by_user", data: { username: "bulk-poster" } });
+      send(adminWs, { type: "delete_by_user", data: { clientId: cid } });
       await flush();
 
       const removes = adminMsgs.filter((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
@@ -555,15 +552,15 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("non-admin delete_by_user is silently ignored", async () => {
-      const { ws: ws1 } = await connectAndJoin("poster");
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("hacker");
+      const { ws: ws1 } = await connectAndJoin("dbu-poster");
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("dbu-hacker");
 
       send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "keep this" } });
       await flush();
 
       msgs2.length = 0;
 
-      send(ws2, { type: "delete_by_user", data: { username: "poster" } });
+      send(ws2, { type: "delete_by_user", data: { clientId: "some-fake-id" } });
       await flush();
 
       const removes = msgs2.filter((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
@@ -578,10 +575,9 @@ describe("ChatRoom Durable Object", () => {
 
   describe("admin flag", () => {
     it("admin can flag a user, which blocks their IP and responds with FLAGGED", async () => {
-      const { ws: userWs, msgs: userMsgs } = await connectAndJoin("bad-user", { ip: "10.0.0.99" });
+      const { ws: userWs, msgs: userMsgs } = await connectAndJoin("bad-user");
       const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
         token: "test-admin-secret",
-        ip: "10.0.0.1",
       });
 
       userMsgs.length = 0;
@@ -603,7 +599,7 @@ describe("ChatRoom Durable Object", () => {
       expect(flagged).toMatchObject({
         type: SERVER_MESSAGE_TYPE.FLAGGED,
         username: "bad-user",
-        ip: "10.0.0.99",
+        clientId: expect.any(String),
         messageId: msgId,
       });
 
@@ -615,8 +611,8 @@ describe("ChatRoom Durable Object", () => {
     });
 
     it("non-admin flag request is silently ignored", async () => {
-      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("target", { ip: "10.0.0.10" });
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("hacker", { ip: "10.0.0.11" });
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("flag-target");
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("flag-hacker");
 
       msgs1.length = 0;
       msgs2.length = 0;
@@ -772,7 +768,7 @@ describe("ChatRoom Durable Object", () => {
       const _msgs1 = collect(ws1);
       await flush();
 
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("observer");
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("spec-observer");
       msgs2.length = 0;
 
       send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "ghost message" } });
@@ -803,6 +799,77 @@ describe("ChatRoom Durable Object", () => {
       expect(msg).toMatchObject({ type: SERVER_MESSAGE_TYPE.MESSAGE, text: "still here" });
 
       ws.close();
+    });
+  });
+
+  // ── Rename ──────────────────────────────────────────────────────
+
+  describe("rename", () => {
+    it("re-joining with new username broadcasts rename and updates history", async () => {
+      const cid = crypto.randomUUID();
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("old-name", { clientId: cid });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("rename-watcher");
+
+      send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "hello" } });
+      await flush();
+
+      msgs1.length = 0;
+      msgs2.length = 0;
+
+      send(ws1, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "new-name", clientId: cid } });
+      await flush();
+
+      const rename = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.RENAME);
+      expect(rename).toMatchObject({
+        type: SERVER_MESSAGE_TYPE.RENAME,
+        oldUsername: "old-name",
+        newUsername: "new-name",
+      });
+
+      const { ws: ws3, msgs: msgs3 } = await connectAndJoin("late-joiner");
+      const history = msgs3.find((m) => m.type === SERVER_MESSAGE_TYPE.HISTORY);
+      if (history && history.type === SERVER_MESSAGE_TYPE.HISTORY) {
+        const fromRenamed = history.messages.filter((m) => m.username === "new-name");
+        expect(fromRenamed.length).toBeGreaterThanOrEqual(1);
+        const fromOld = history.messages.filter((m) => m.username === "old-name");
+        expect(fromOld).toHaveLength(0);
+      }
+
+      ws1.close();
+      ws2.close();
+      ws3.close();
+    });
+
+    it("flag works after user has renamed", async () => {
+      const cid = crypto.randomUUID();
+      const { ws: userWs, msgs: userMsgs } = await connectAndJoin("original", { clientId: cid });
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+      });
+
+      send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "bad content" } });
+      await flush();
+
+      const chatMsg = adminMsgs.find((m): m is ChatMessage => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      const msgId = chatMsg?.id;
+
+      send(userWs, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "renamed", clientId: cid } });
+      await flush();
+
+      adminMsgs.length = 0;
+      userMsgs.length = 0;
+
+      send(adminWs, { type: "flag", data: { id: msgId } });
+      await flush();
+
+      const flagged = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.FLAGGED);
+      expect(flagged).toBeDefined();
+
+      const blocked = userMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.BLOCKED);
+      expect(blocked).toBeDefined();
+
+      adminWs.close();
+      userWs.close();
     });
   });
 });

--- a/api/src/__tests__/chat-room.test.ts
+++ b/api/src/__tests__/chat-room.test.ts
@@ -315,55 +315,20 @@ describe("ChatRoom Durable Object", () => {
   // ── IP Blocking ─────────────────────────────────────────────────
 
   describe("IP blocking", () => {
-    it("admin can unblock an IP via /unblock command", async () => {
+    it("admin can unblock an IP via unblock message", async () => {
       const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
         token: "test-admin-secret",
         ip: "10.0.0.1",
       });
       adminMsgs.length = 0;
 
-      send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/unblock 10.0.0.50" } });
+      send(adminWs, { type: CLIENT_MESSAGE_TYPE.UNBLOCK, data: { ip: "10.0.0.50" } });
       await flush();
 
       const unblocked = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.UNBLOCKED);
       expect(unblocked).toMatchObject({ type: SERVER_MESSAGE_TYPE.UNBLOCKED, ip: "10.0.0.50" });
 
       adminWs.close();
-    });
-
-    it("non-owner /unblock command is treated as regular chat text", async () => {
-      const { ws, msgs } = await connectAndJoin("regular-user", { ip: "10.0.0.2" });
-      msgs.length = 0;
-
-      send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/unblock 10.0.0.50" } });
-      await flush();
-
-      const chatMsg = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
-      expect(chatMsg).toMatchObject({
-        type: SERVER_MESSAGE_TYPE.MESSAGE,
-        username: "regular-user",
-        text: "/unblock 10.0.0.50",
-      });
-
-      ws.close();
-    });
-
-    it("/unblock command is not broadcast as a chat message", async () => {
-      const { ws: adminWs } = await connectAndJoin("thalida", {
-        token: "test-admin-secret",
-        ip: "10.0.0.1",
-      });
-      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("viewer", { ip: "10.0.0.2" });
-      otherMsgs.length = 0;
-
-      send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/unblock 10.0.0.50" } });
-      await flush();
-
-      const chatMsgs = otherMsgs.filter((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
-      expect(chatMsgs).toHaveLength(0);
-
-      adminWs.close();
-      otherWs.close();
     });
   });
 
@@ -383,7 +348,7 @@ describe("ChatRoom Durable Object", () => {
         expect(help.commands.length).toBeGreaterThanOrEqual(2);
         const names = help.commands.map((c) => c.name);
         expect(names).toContain("help");
-        expect(names).toContain("unblock");
+        expect(names).toContain("blocked");
       }
 
       ws.close();
@@ -423,27 +388,6 @@ describe("ChatRoom Durable Object", () => {
       expect(msg).toMatchObject({ type: SERVER_MESSAGE_TYPE.MESSAGE, username: "regular", text: "/help" });
 
       ws1.close();
-      ws2.close();
-    });
-
-    it("non-admin /unblock sends as regular chat message", async () => {
-      const { ws, msgs } = await connectAndJoin("regular-user", { ip: "10.0.0.2" });
-      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("watcher", { ip: "10.0.0.3" });
-
-      msgs.length = 0;
-      msgs2.length = 0;
-
-      send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/unblock 10.0.0.50" } });
-      await flush();
-
-      const msg = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
-      expect(msg).toMatchObject({
-        type: SERVER_MESSAGE_TYPE.MESSAGE,
-        username: "regular-user",
-        text: "/unblock 10.0.0.50",
-      });
-
-      ws.close();
       ws2.close();
     });
 

--- a/api/src/__tests__/chat-room.test.ts
+++ b/api/src/__tests__/chat-room.test.ts
@@ -331,17 +331,18 @@ describe("ChatRoom Durable Object", () => {
       adminWs.close();
     });
 
-    it("non-owner /unblock command returns unauthorized error", async () => {
+    it("non-owner /unblock command is treated as regular chat text", async () => {
       const { ws, msgs } = await connectAndJoin("regular-user", { ip: "10.0.0.2" });
       msgs.length = 0;
 
       send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/unblock 10.0.0.50" } });
       await flush();
 
-      const error = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.ERROR);
-      expect(error).toMatchObject({
-        type: SERVER_MESSAGE_TYPE.ERROR,
-        code: SERVER_ERROR_CODE.UNAUTHORIZED,
+      const chatMsg = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      expect(chatMsg).toMatchObject({
+        type: SERVER_MESSAGE_TYPE.MESSAGE,
+        username: "regular-user",
+        text: "/unblock 10.0.0.50",
       });
 
       ws.close();

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -10,6 +10,7 @@ import type {
   ClientFlagData,
   ClientJoinData,
   ClientMessage,
+  ClientRenameData,
   ConnectionInfo,
   ServerErrorCode,
   ServerMessage,
@@ -23,14 +24,15 @@ import {
   MAX_WARNINGS,
   MIN_USERNAME_LENGTH,
   RESERVATION_DURATION_MS,
+  generateRandomUsername,
 } from "./config";
 
 const BLOCKED_IPS_KEY = "blockedIps";
 const MESSAGES_KEY = "messages";
-const RESERVATION_PREFIX = "reservation:";
+const CLIENT_PREFIX = "client:";
 
-interface UsernameReservation {
-  clientId: string;
+interface ClientMapping {
+  username: string;
   lastSeen: number;
 }
 
@@ -139,29 +141,46 @@ export class ChatRoom implements DurableObject {
     this.saveBlockedClients();
   }
 
-  private async getReservation(username: string): Promise<UsernameReservation | undefined> {
-    return this.state.storage.get<UsernameReservation>(`${RESERVATION_PREFIX}${username}`);
+  private async getClientMapping(clientId: string): Promise<ClientMapping | undefined> {
+    return this.state.storage.get<ClientMapping>(`${CLIENT_PREFIX}${clientId}`);
   }
 
-  private async upsertReservation(username: string, clientId: string): Promise<void> {
-    await this.state.storage.put<UsernameReservation>(`${RESERVATION_PREFIX}${username}`, {
-      clientId,
+  private async setClientMapping(clientId: string, username: string): Promise<void> {
+    await this.state.storage.put<ClientMapping>(`${CLIENT_PREFIX}${clientId}`, {
+      username,
       lastSeen: Date.now(),
     });
   }
 
-  private async cleanupExpiredReservations(): Promise<void> {
-    const all = await this.state.storage.list<UsernameReservation>({ prefix: RESERVATION_PREFIX });
-    const now = Date.now();
+  private async isUsernameTaken(username: string, excludeClientId: string): Promise<boolean> {
+    // Check active connections first
+    for (const info of this.connections.values()) {
+      if (info.username === username && info.clientId !== excludeClientId) {
+        return true;
+      }
+    }
+    // Check stored mappings
+    const all = await this.state.storage.list<ClientMapping>({ prefix: CLIENT_PREFIX });
+    for (const [key, value] of all) {
+      const cid = key.slice(CLIENT_PREFIX.length);
+      if (cid !== excludeClientId && value.username === username) {
+        const expired = Date.now() - value.lastSeen > RESERVATION_DURATION_MS;
+        if (!expired) return true;
+      }
+    }
+    return false;
+  }
+
+  private async cleanupExpiredClients(): Promise<void> {
+    const all = await this.state.storage.list<ClientMapping>({ prefix: CLIENT_PREFIX });
     const expired: string[] = [];
+    const now = Date.now();
     for (const [key, value] of all) {
       if (now - value.lastSeen > RESERVATION_DURATION_MS) {
         expired.push(key);
       }
     }
-    if (expired.length > 0) {
-      await this.state.storage.delete(expired);
-    }
+    if (expired.length > 0) await this.state.storage.delete(expired);
   }
 
   // ── Public API ───────────────────────────────────────────────────────
@@ -173,8 +192,8 @@ export class ChatRoom implements DurableObject {
 
     await this.loadBlockedClients();
     await this.loadMessages();
-    this.cleanupExpiredReservations().catch((err) => {
-      console.error("[reservations] cleanup error:", err);
+    this.cleanupExpiredClients().catch((err) => {
+      console.error("[clients] cleanup error:", err);
     });
 
     const [client, server] = Object.values(new WebSocketPair());
@@ -223,6 +242,9 @@ export class ChatRoom implements DurableObject {
       case CLIENT_MESSAGE_TYPE.JOIN:
         this.handleJoin(ws, msg.data);
         break;
+      case CLIENT_MESSAGE_TYPE.RENAME:
+        this.handleRename(ws, msg.data);
+        break;
       case CLIENT_MESSAGE_TYPE.MESSAGE:
         this.handleChatMessage(ws, msg.data);
         break;
@@ -241,64 +263,27 @@ export class ChatRoom implements DurableObject {
     }
   }
 
-  private async handleJoin(ws: WebSocket, { username, token, clientId }: ClientJoinData): Promise<void> {
+  private async handleJoin(ws: WebSocket, { token, clientId }: ClientJoinData): Promise<void> {
     const isOwner = typeof token === "string" && token.length > 0 && token === this.env.ADMIN_SECRET;
-
     const resolvedClientId = clientId ?? crypto.randomUUID();
     const isBlocked = !isOwner && this.blockedEntries.has(resolvedClientId);
 
-    const name = isOwner
-      ? ADMIN_USERNAME
-      : String(username ?? "")
-          .trim()
-          .toLowerCase();
-
-    const usernamePattern = new RegExp(`^[a-z0-9_\\-.]{${MIN_USERNAME_LENGTH},${MAX_USERNAME_LENGTH}}$`);
-    if (!usernamePattern.test(name)) {
-      this.sendError(
-        ws,
-        SERVER_ERROR_CODE.INVALID_USERNAME,
-        `Username must be ${MIN_USERNAME_LENGTH}-${MAX_USERNAME_LENGTH} characters: lowercase letters, numbers, hyphens, underscores, or dots.`,
-      );
-      return;
-    }
-
-    if (name.includes(ADMIN_USERNAME) && !isOwner) {
-      this.sendError(ws, SERVER_ERROR_CODE.RESERVED_USERNAME, "That name contains a reserved word.");
-      return;
-    }
-
-    for (const [existingWs, info] of this.connections) {
-      if (info.username === name && existingWs !== ws && !(isOwner && info.isOwner)) {
-        if (resolvedClientId && info.clientId === resolvedClientId) continue;
-        this.sendError(ws, SERVER_ERROR_CODE.TAKEN_USERNAME, "That name is already taken.");
-        return;
-      }
-    }
-
-    if (!isOwner && resolvedClientId) {
-      const reservation = await this.getReservation(name);
-      if (reservation) {
-        const expired = Date.now() - reservation.lastSeen > RESERVATION_DURATION_MS;
-        if (reservation.clientId === resolvedClientId && expired) {
-          this.sendError(ws, SERVER_ERROR_CODE.EXPIRED_USERNAME, "Your reserved username has expired.");
-          return;
+    let name: string;
+    if (isOwner) {
+      name = ADMIN_USERNAME;
+    } else {
+      const mapping = await this.getClientMapping(resolvedClientId);
+      if (mapping) {
+        name = mapping.username;
+        await this.setClientMapping(resolvedClientId, name); // update lastSeen
+      } else {
+        name = generateRandomUsername();
+        // Ensure generated name isn't taken
+        while (await this.isUsernameTaken(name, resolvedClientId)) {
+          name = generateRandomUsername();
         }
-        if (reservation.clientId !== resolvedClientId && !expired) {
-          this.sendError(ws, SERVER_ERROR_CODE.TAKEN_USERNAME, "That name is already taken.");
-          return;
-        }
+        await this.setClientMapping(resolvedClientId, name);
       }
-      await this.upsertReservation(name, resolvedClientId);
-    }
-
-    // Detect rename: same clientId, different username
-    const existingConn = this.connections.get(ws);
-    const oldUsername = existingConn?.clientId === resolvedClientId ? existingConn.username : undefined;
-
-    if (oldUsername != null && oldUsername !== name) {
-      this.renameMessagesForClient(resolvedClientId, name);
-      this.broadcast({ type: SERVER_MESSAGE_TYPE.RENAME, oldUsername, newUsername: name });
     }
 
     this.spectators.delete(ws);
@@ -314,6 +299,47 @@ export class ChatRoom implements DurableObject {
     this.send(ws, { type: SERVER_MESSAGE_TYPE.JOINED, isOwner, username: name, isBlocked });
     if (connInfo) this.sendHistory(ws, connInfo);
     this.broadcastStatus();
+  }
+
+  private async handleRename(ws: WebSocket, { username }: ClientRenameData): Promise<void> {
+    const info = this.connections.get(ws);
+    if (!info) return;
+
+    if (info.isOwner) {
+      this.sendError(ws, SERVER_ERROR_CODE.UNAUTHORIZED, "Admin cannot rename.");
+      return;
+    }
+
+    const name = String(username ?? "")
+      .trim()
+      .toLowerCase();
+
+    const usernamePattern = new RegExp(`^[a-z0-9_\\-.]{${MIN_USERNAME_LENGTH},${MAX_USERNAME_LENGTH}}$`);
+    if (!usernamePattern.test(name)) {
+      this.sendError(
+        ws,
+        SERVER_ERROR_CODE.INVALID_USERNAME,
+        `Username must be ${MIN_USERNAME_LENGTH}-${MAX_USERNAME_LENGTH} characters: lowercase letters, numbers, hyphens, underscores, or dots.`,
+      );
+      return;
+    }
+
+    if (name.includes(ADMIN_USERNAME)) {
+      this.sendError(ws, SERVER_ERROR_CODE.RESERVED_USERNAME, "That name contains a reserved word.");
+      return;
+    }
+
+    if (await this.isUsernameTaken(name, info.clientId)) {
+      this.sendError(ws, SERVER_ERROR_CODE.TAKEN_USERNAME, "That name is already taken.");
+      return;
+    }
+
+    const oldUsername = info.username;
+    await this.setClientMapping(info.clientId, name);
+    this.renameMessagesForClient(info.clientId, name);
+    info.username = name;
+    this.broadcast({ type: SERVER_MESSAGE_TYPE.RENAME, oldUsername, newUsername: name });
+    this.send(ws, { type: SERVER_MESSAGE_TYPE.JOINED, isOwner: false, username: name, isBlocked: info.isBlocked });
   }
 
   private handleChatMessage(ws: WebSocket, { text: rawText, context }: ClientChatData): void {

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -340,6 +340,7 @@ export class ChatRoom implements DurableObject {
     info.username = name;
     this.broadcast({ type: SERVER_MESSAGE_TYPE.RENAME, oldUsername, newUsername: name });
     this.send(ws, { type: SERVER_MESSAGE_TYPE.JOINED, isOwner: false, username: name, isBlocked: info.isBlocked });
+    this.broadcastStatus();
   }
 
   private handleChatMessage(ws: WebSocket, { text: rawText, context }: ClientChatData): void {
@@ -635,10 +636,17 @@ export class ChatRoom implements DurableObject {
   private buildStatusMessage(): ServerMessage {
     let isOwnerOnline = false;
     const uniqueClients = new Set<string>();
+    const uniqueUsernames = new Set<string>();
     for (const info of this.connections.values()) {
       if (info.isOwner) isOwnerOnline = true;
       uniqueClients.add(info.clientId);
+      uniqueUsernames.add(info.username);
     }
-    return { type: SERVER_MESSAGE_TYPE.STATUS, isOwnerOnline, userCount: uniqueClients.size };
+    return {
+      type: SERVER_MESSAGE_TYPE.STATUS,
+      isOwnerOnline,
+      userCount: uniqueClients.size,
+      onlineUsernames: [...uniqueUsernames],
+    };
   }
 }

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -4,6 +4,7 @@ import type {
   Env,
   ChatMessage,
   ClientChatData,
+  ClientDeleteByUserData,
   ClientDeleteData,
   ClientFlagData,
   ClientJoinData,
@@ -165,6 +166,9 @@ export class ChatRoom implements DurableObject {
         break;
       case CLIENT_MESSAGE_TYPE.FLAG:
         this.handleFlag(ws, msg.data);
+        break;
+      case CLIENT_MESSAGE_TYPE.DELETE_BY_USER:
+        this.handleDeleteByUser(ws, msg.data);
         break;
     }
   }
@@ -342,6 +346,18 @@ export class ChatRoom implements DurableObject {
       ip: targetIp,
       messageId: id,
     });
+  }
+
+  private handleDeleteByUser(ws: WebSocket, { username: targetUsername }: ClientDeleteByUserData): void {
+    const info = this.connections.get(ws);
+    if (!info?.isOwner) return;
+
+    const toRemove = this.messages.filter((m) => m.username === targetUsername);
+    this.messages = this.messages.filter((m) => m.username !== targetUsername);
+
+    for (const msg of toRemove) {
+      this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id: msg.id });
+    }
   }
 
   // ── Moderation ───────────────────────────────────────────────────────

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -115,16 +115,6 @@ export class ChatRoom implements DurableObject {
 
     server.accept();
 
-    if (this.blockedEntries.has(ip)) {
-      this.sendBlocked(
-        server,
-        SERVER_ERROR_CODE.MODERATION_BLOCKED,
-        "You have been blocked due to repeated violations.",
-      );
-      server.close(1008, "blocked");
-      return new Response(null, { status: 101, webSocket: client });
-    }
-
     this.ipBySocket.set(server, ip);
     this.spectators.add(server);
     this.sendStatus(server);
@@ -155,6 +145,15 @@ export class ChatRoom implements DurableObject {
       return;
     }
 
+    const info = this.connections.get(ws);
+    if (info?.isBlocked && msg.type !== CLIENT_MESSAGE_TYPE.JOIN) {
+      this.sendBlocked(ws);
+      return;
+    }
+    if (info?.isBlocked && msg.type === CLIENT_MESSAGE_TYPE.JOIN) {
+      return;
+    }
+
     switch (msg.type) {
       case CLIENT_MESSAGE_TYPE.JOIN:
         this.handleJoin(ws, msg.data);
@@ -171,11 +170,16 @@ export class ChatRoom implements DurableObject {
       case CLIENT_MESSAGE_TYPE.DELETE_BY_USER:
         this.handleDeleteByUser(ws, msg.data);
         break;
+      case CLIENT_MESSAGE_TYPE.UNBLOCK:
+        this.handleUnblock(ws, msg.data.ip);
+        break;
     }
   }
 
   private async handleJoin(ws: WebSocket, { username, token, clientId }: ClientJoinData): Promise<void> {
     const isOwner = typeof token === "string" && token.length > 0 && token === this.env.ADMIN_SECRET;
+
+    const ipBlocked = !isOwner && this.blockedEntries.has(this.ipBySocket.get(ws) ?? "unknown");
 
     const name = isOwner
       ? ADMIN_USERNAME
@@ -229,11 +233,11 @@ export class ChatRoom implements DurableObject {
       username: name,
       isOwner,
       warnings: 0,
-      isBlocked: false,
+      isBlocked: ipBlocked,
       clientId: clientId ?? undefined,
     });
 
-    this.send(ws, { type: SERVER_MESSAGE_TYPE.JOINED, isOwner, username: name });
+    this.send(ws, { type: SERVER_MESSAGE_TYPE.JOINED, isOwner, username: name, isBlocked: ipBlocked });
     this.send(ws, { type: SERVER_MESSAGE_TYPE.HISTORY, messages: this.messages });
     this.broadcastStatus();
   }
@@ -241,15 +245,6 @@ export class ChatRoom implements DurableObject {
   private handleChatMessage(ws: WebSocket, { text: rawText, context }: ClientChatData): void {
     const info = this.connections.get(ws);
     if (!info) return;
-
-    if (info.isBlocked) {
-      this.sendBlocked(
-        ws,
-        SERVER_ERROR_CODE.MODERATION_BLOCKED,
-        "You have been blocked from sending messages due to repeated violations.",
-      );
-      return;
-    }
 
     const text = String(rawText ?? "")
       .trim()
@@ -293,6 +288,23 @@ export class ChatRoom implements DurableObject {
       console.error("[unblock] failed to persist unblock:", err);
     });
     this.send(ws, { type: SERVER_MESSAGE_TYPE.UNBLOCKED, ip });
+
+    for (const [sock, connInfo] of this.connections) {
+      if (connInfo.ip === ip && connInfo.isBlocked) {
+        connInfo.isBlocked = false;
+        this.send(sock, {
+          type: SERVER_MESSAGE_TYPE.JOINED,
+          isOwner: false,
+          username: connInfo.username,
+          isBlocked: false,
+        });
+        this.send(sock, {
+          type: SERVER_MESSAGE_TYPE.WARNING,
+          code: SERVER_ERROR_CODE.UNBLOCKED,
+          message: "You have been unblocked.",
+        });
+      }
+    }
   }
 
   private handleDelete(ws: WebSocket, { id }: ClientDeleteData): void {
@@ -335,7 +347,7 @@ export class ChatRoom implements DurableObject {
     // Send BLOCKED to all of the target's sockets
     for (const [targetWs, connInfo] of this.connections) {
       if (connInfo.ip === targetIp && !connInfo.isOwner) {
-        this.sendBlocked(targetWs, SERVER_ERROR_CODE.MODERATION_BLOCKED, "You have been blocked by the admin.");
+        this.sendBlocked(targetWs);
         connInfo.isBlocked = true;
       }
     }
@@ -394,11 +406,7 @@ export class ChatRoom implements DurableObject {
       this.persistBlockedIps().catch((err) => {
         console.error("[block] failed to persist blocked IP:", err);
       });
-      this.sendBlocked(
-        ws,
-        SERVER_ERROR_CODE.MODERATION_BLOCKED,
-        "You have been blocked from sending messages due to repeated violations.",
-      );
+      this.sendBlocked(ws);
     } else {
       const remaining = MAX_WARNINGS - info.warnings;
       this.sendWarning(
@@ -460,10 +468,6 @@ export class ChatRoom implements DurableObject {
     this.send(ws, message);
   }
 
-  handleUnblockCommand(ws: WebSocket, ip: string): void {
-    this.handleUnblock(ws, ip);
-  }
-
   handleDeleteMessage(ws: WebSocket, messageId: string): void {
     this.handleDelete(ws, { id: messageId });
   }
@@ -504,8 +508,12 @@ export class ChatRoom implements DurableObject {
     this.send(ws, { type: SERVER_MESSAGE_TYPE.WARNING, code, message });
   }
 
-  private sendBlocked(ws: WebSocket, code: ServerErrorCode, message: string): void {
-    this.send(ws, { type: SERVER_MESSAGE_TYPE.BLOCKED, code, message });
+  private sendBlocked(ws: WebSocket): void {
+    this.send(ws, {
+      type: SERVER_MESSAGE_TYPE.BLOCKED,
+      code: SERVER_ERROR_CODE.MODERATION_BLOCKED,
+      message: "You have been blocked.",
+    });
   }
 
   private sendStatus(ws: WebSocket): void {

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -4,6 +4,7 @@ import type {
   Env,
   ChatMessage,
   ClientChatData,
+  ClientDeleteData,
   ClientJoinData,
   ClientMessage,
   ConnectionInfo,
@@ -158,6 +159,9 @@ export class ChatRoom implements DurableObject {
       case CLIENT_MESSAGE_TYPE.MESSAGE:
         this.handleChatMessage(ws, msg.data);
         break;
+      case CLIENT_MESSAGE_TYPE.DELETE:
+        this.handleDelete(ws, msg.data);
+        break;
     }
   }
 
@@ -282,6 +286,17 @@ export class ChatRoom implements DurableObject {
     this.send(ws, { type: SERVER_MESSAGE_TYPE.UNBLOCKED, ip });
   }
 
+  private handleDelete(ws: WebSocket, { id }: ClientDeleteData): void {
+    const info = this.connections.get(ws);
+    if (!info?.isOwner) return;
+
+    const idx = this.messages.findIndex((m) => m.id === id);
+    if (idx === -1) return;
+
+    this.messages.splice(idx, 1);
+    this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id });
+  }
+
   // ── Moderation ───────────────────────────────────────────────────────
 
   private async moderate(message: ChatMessage, senderWs: WebSocket): Promise<void> {
@@ -383,6 +398,10 @@ export class ChatRoom implements DurableObject {
 
   handleUnblockCommand(ws: WebSocket, ip: string): void {
     this.handleUnblock(ws, ip);
+  }
+
+  handleDeleteMessage(ws: WebSocket, messageId: string): void {
+    this.handleDelete(ws, { id: messageId });
   }
 
   // ── Connection Helpers ───────────────────────────────────────────────

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -1,4 +1,5 @@
 import { v7 as uuidv7 } from "uuid";
+import { dispatch } from "./commands";
 import type {
   Env,
   ChatMessage,
@@ -228,10 +229,8 @@ export class ChatRoom implements DurableObject {
       .slice(0, MAX_MESSAGE_LENGTH);
     if (!text) return;
 
-    const unblockMatch = text.match(/^\/unblock\s+(.+)$/);
-    if (unblockMatch) {
-      this.handleUnblock(ws, unblockMatch[1].trim());
-      return;
+    if (info.isOwner && text.startsWith("/")) {
+      if (dispatch(text, ws, this)) return;
     }
 
     const message: ChatMessage = {
@@ -360,6 +359,16 @@ export class ChatRoom implements DurableObject {
 
     console.error("[moderation] exhausted retries after 429s");
     return null;
+  }
+
+  // ── Command Interface ──────────────────────────────────────────────
+
+  sendToSocket(ws: WebSocket, message: ServerMessage): void {
+    this.send(ws, message);
+  }
+
+  handleUnblockCommand(ws: WebSocket, ip: string): void {
+    this.handleUnblock(ws, ip);
   }
 
   // ── Connection Helpers ───────────────────────────────────────────────

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -37,7 +37,6 @@ export class ChatRoom implements DurableObject {
   private messages: ChatMessage[] = [];
   private connections: Map<WebSocket, ConnectionInfo> = new Map();
   private spectators: Set<WebSocket> = new Set();
-  private ipBySocket: Map<WebSocket, string> = new Map();
   private blockedEntries: Map<string, { username: string; blockedAt: number }> = new Map();
   private blockedIpsLoaded = false;
 
@@ -46,27 +45,23 @@ export class ChatRoom implements DurableObject {
     private env: Env,
   ) {}
 
-  private async loadBlockedIps(): Promise<void> {
+  private async loadBlockedClients(): Promise<void> {
     if (this.blockedIpsLoaded) return;
     const stored = await this.state.storage.get<unknown>(BLOCKED_IPS_KEY);
     if (Array.isArray(stored)) {
       for (const entry of stored) {
-        if (typeof entry === "string") {
-          // Old format: plain IP strings
-          this.blockedEntries.set(entry, { username: "unknown", blockedAt: 0 });
-        } else if (entry && typeof entry === "object" && "ip" in entry) {
-          // New format: { ip, username, blockedAt }
-          const e = entry as { ip: string; username: string; blockedAt: number };
-          this.blockedEntries.set(e.ip, { username: e.username, blockedAt: e.blockedAt });
+        if (entry && typeof entry === "object" && "clientId" in entry) {
+          const e = entry as { clientId: string; username: string; blockedAt: number };
+          this.blockedEntries.set(e.clientId, { username: e.username, blockedAt: e.blockedAt });
         }
       }
     }
     this.blockedIpsLoaded = true;
   }
 
-  private async persistBlockedIps(): Promise<void> {
-    const entries = [...this.blockedEntries.entries()].map(([ip, info]) => ({
-      ip,
+  private async persistBlockedClients(): Promise<void> {
+    const entries = [...this.blockedEntries.entries()].map(([clientId, info]) => ({
+      clientId,
       username: info.username,
       blockedAt: info.blockedAt,
     }));
@@ -105,17 +100,15 @@ export class ChatRoom implements DurableObject {
       return new Response("Expected WebSocket", { status: 426 });
     }
 
-    await this.loadBlockedIps();
+    await this.loadBlockedClients();
     this.cleanupExpiredReservations().catch((err) => {
       console.error("[reservations] cleanup error:", err);
     });
 
-    const ip = request.headers.get("CF-Connecting-IP") ?? "unknown";
     const [client, server] = Object.values(new WebSocketPair());
 
     server.accept();
 
-    this.ipBySocket.set(server, ip);
     this.spectators.add(server);
     this.sendStatus(server);
 
@@ -171,7 +164,7 @@ export class ChatRoom implements DurableObject {
         this.handleDeleteByUser(ws, msg.data);
         break;
       case CLIENT_MESSAGE_TYPE.UNBLOCK:
-        this.handleUnblock(ws, msg.data.ip);
+        this.handleUnblock(ws, msg.data.clientId);
         break;
     }
   }
@@ -179,7 +172,8 @@ export class ChatRoom implements DurableObject {
   private async handleJoin(ws: WebSocket, { username, token, clientId }: ClientJoinData): Promise<void> {
     const isOwner = typeof token === "string" && token.length > 0 && token === this.env.ADMIN_SECRET;
 
-    const ipBlocked = !isOwner && this.blockedEntries.has(this.ipBySocket.get(ws) ?? "unknown");
+    const resolvedClientId = clientId ?? crypto.randomUUID();
+    const isBlocked = !isOwner && this.blockedEntries.has(resolvedClientId);
 
     const name = isOwner
       ? ADMIN_USERNAME
@@ -204,40 +198,51 @@ export class ChatRoom implements DurableObject {
 
     for (const [existingWs, info] of this.connections) {
       if (info.username === name && existingWs !== ws && !(isOwner && info.isOwner)) {
-        // Allow the same clientId to reuse their username across multiple tabs
-        if (clientId && info.clientId === clientId) continue;
+        if (resolvedClientId && info.clientId === resolvedClientId) continue;
         this.sendError(ws, SERVER_ERROR_CODE.TAKEN_USERNAME, "That name is already taken.");
         return;
       }
     }
 
-    if (!isOwner && clientId) {
+    if (!isOwner && resolvedClientId) {
       const reservation = await this.getReservation(name);
       if (reservation) {
         const expired = Date.now() - reservation.lastSeen > RESERVATION_DURATION_MS;
-        if (reservation.clientId === clientId && expired) {
+        if (reservation.clientId === resolvedClientId && expired) {
           this.sendError(ws, SERVER_ERROR_CODE.EXPIRED_USERNAME, "Your reserved username has expired.");
           return;
         }
-        if (reservation.clientId !== clientId && !expired) {
+        if (reservation.clientId !== resolvedClientId && !expired) {
           this.sendError(ws, SERVER_ERROR_CODE.TAKEN_USERNAME, "That name is already taken.");
           return;
         }
       }
-      await this.upsertReservation(name, clientId);
+      await this.upsertReservation(name, resolvedClientId);
+    }
+
+    // Detect rename: same clientId, different username
+    const existingConn = this.connections.get(ws);
+    const oldUsername = existingConn?.clientId === resolvedClientId ? existingConn.username : undefined;
+
+    if (oldUsername != null && oldUsername !== name) {
+      for (const msg of this.messages) {
+        if (msg.clientId === resolvedClientId) {
+          msg.username = name;
+        }
+      }
+      this.broadcast({ type: SERVER_MESSAGE_TYPE.RENAME, oldUsername, newUsername: name });
     }
 
     this.spectators.delete(ws);
     this.connections.set(ws, {
-      ip: this.ipBySocket.get(ws) ?? "unknown",
+      clientId: resolvedClientId,
       username: name,
       isOwner,
       warnings: 0,
-      isBlocked: ipBlocked,
-      clientId: clientId ?? undefined,
+      isBlocked,
     });
 
-    this.send(ws, { type: SERVER_MESSAGE_TYPE.JOINED, isOwner, username: name, isBlocked: ipBlocked });
+    this.send(ws, { type: SERVER_MESSAGE_TYPE.JOINED, isOwner, username: name, isBlocked });
     this.send(ws, { type: SERVER_MESSAGE_TYPE.HISTORY, messages: this.messages });
     this.broadcastStatus();
   }
@@ -258,6 +263,7 @@ export class ChatRoom implements DurableObject {
     const message: ChatMessage = {
       type: SERVER_MESSAGE_TYPE.MESSAGE,
       id: uuidv7(),
+      clientId: info.clientId,
       username: info.username,
       text,
       timestamp: Date.now(),
@@ -276,21 +282,21 @@ export class ChatRoom implements DurableObject {
     });
   }
 
-  private handleUnblock(ws: WebSocket, ip: string): void {
+  private handleUnblock(ws: WebSocket, clientId: string): void {
     const info = this.connections.get(ws);
     if (!info?.isOwner) {
       this.sendError(ws, SERVER_ERROR_CODE.UNAUTHORIZED, "Only the owner can unblock users.");
       return;
     }
 
-    this.blockedEntries.delete(ip);
-    this.persistBlockedIps().catch((err) => {
+    this.blockedEntries.delete(clientId);
+    this.persistBlockedClients().catch((err: unknown) => {
       console.error("[unblock] failed to persist unblock:", err);
     });
-    this.send(ws, { type: SERVER_MESSAGE_TYPE.UNBLOCKED, ip });
+    this.send(ws, { type: SERVER_MESSAGE_TYPE.UNBLOCKED, clientId });
 
     for (const [sock, connInfo] of this.connections) {
-      if (connInfo.ip === ip && connInfo.isBlocked) {
+      if (connInfo.clientId === clientId && connInfo.isBlocked) {
         connInfo.isBlocked = false;
         this.send(sock, {
           type: SERVER_MESSAGE_TYPE.JOINED,
@@ -325,48 +331,35 @@ export class ChatRoom implements DurableObject {
     const message = this.messages.find((m) => m.id === id);
     if (!message) return;
 
-    const targetUsername = message.username;
+    const targetClientId = message.clientId;
+    if (!targetClientId) return;
 
-    // Find the target's IP from their connection
-    let targetIp: string | undefined;
-    for (const [, connInfo] of this.connections) {
-      if (connInfo.username === targetUsername && !connInfo.isOwner) {
-        targetIp = connInfo.ip;
-        break;
-      }
-    }
-
-    if (!targetIp) return;
-
-    // Block the IP
-    this.blockedEntries.set(targetIp, { username: targetUsername, blockedAt: Date.now() });
-    this.persistBlockedIps().catch((err) => {
-      console.error("[flag] failed to persist blocked IP:", err);
+    this.blockedEntries.set(targetClientId, { username: message.username, blockedAt: Date.now() });
+    this.persistBlockedClients().catch((err: unknown) => {
+      console.error("[flag] failed to persist blocked client:", err);
     });
 
-    // Send BLOCKED to all of the target's sockets
     for (const [targetWs, connInfo] of this.connections) {
-      if (connInfo.ip === targetIp && !connInfo.isOwner) {
+      if (connInfo.clientId === targetClientId && !connInfo.isOwner) {
         this.sendBlocked(targetWs);
         connInfo.isBlocked = true;
       }
     }
 
-    // Respond to admin
     this.send(ws, {
       type: SERVER_MESSAGE_TYPE.FLAGGED,
-      username: targetUsername,
-      ip: targetIp,
+      username: message.username,
+      clientId: targetClientId,
       messageId: id,
     });
   }
 
-  private handleDeleteByUser(ws: WebSocket, { username: targetUsername }: ClientDeleteByUserData): void {
+  private handleDeleteByUser(ws: WebSocket, { clientId: targetClientId }: ClientDeleteByUserData): void {
     const info = this.connections.get(ws);
     if (!info?.isOwner) return;
 
-    const toRemove = this.messages.filter((m) => m.username === targetUsername);
-    this.messages = this.messages.filter((m) => m.username !== targetUsername);
+    const toRemove = this.messages.filter((m) => m.clientId === targetClientId);
+    this.messages = this.messages.filter((m) => m.clientId !== targetClientId);
 
     for (const msg of toRemove) {
       this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id: msg.id });
@@ -402,9 +395,9 @@ export class ChatRoom implements DurableObject {
 
     if (info.warnings >= MAX_WARNINGS) {
       info.isBlocked = true;
-      this.blockedEntries.set(info.ip, { username: info.username, blockedAt: Date.now() });
-      this.persistBlockedIps().catch((err) => {
-        console.error("[block] failed to persist blocked IP:", err);
+      this.blockedEntries.set(info.clientId, { username: info.username, blockedAt: Date.now() });
+      this.persistBlockedClients().catch((err: unknown) => {
+        console.error("[block] failed to persist blocked client:", err);
       });
       this.sendBlocked(ws);
     } else {
@@ -473,8 +466,8 @@ export class ChatRoom implements DurableObject {
   }
 
   getBlockedEntries(): BlockedEntry[] {
-    return [...this.blockedEntries.entries()].map(([ip, info]) => ({
-      ip,
+    return [...this.blockedEntries.entries()].map(([clientId, info]) => ({
+      clientId,
       username: info.username,
       blockedAt: info.blockedAt,
     }));
@@ -483,7 +476,6 @@ export class ChatRoom implements DurableObject {
   // ── Connection Helpers ───────────────────────────────────────────────
 
   private removeConnection(ws: WebSocket): void {
-    this.ipBySocket.delete(ws);
     this.spectators.delete(ws);
     this.connections.delete(ws);
     this.broadcastStatus();
@@ -542,9 +534,7 @@ export class ChatRoom implements DurableObject {
     const uniqueClients = new Set<string>();
     for (const info of this.connections.values()) {
       if (info.isOwner) isOwnerOnline = true;
-      // Deduplicate by clientId (multiple tabs share the same clientId);
-      // fall back to ip+username for connections without one (e.g. owner)
-      uniqueClients.add(info.clientId ?? `${info.ip}:${info.username}`);
+      uniqueClients.add(info.clientId);
     }
     return { type: SERVER_MESSAGE_TYPE.STATUS, isOwnerOnline, userCount: uniqueClients.size };
   }

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -550,6 +550,15 @@ export class ChatRoom implements DurableObject {
     }));
   }
 
+  clearMessages(): void {
+    const ids = this.messages.map((m) => m.id);
+    this.messages = [];
+    this.saveMessages();
+    for (const id of ids) {
+      this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id });
+    }
+  }
+
   // ── Sanitization ────────────────────────────────────────────────────
 
   private sanitizeMessage(msg: ChatMessage, viewer: ConnectionInfo): Record<string, unknown> {

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -34,7 +34,7 @@ export class ChatRoom implements DurableObject {
   private connections: Map<WebSocket, ConnectionInfo> = new Map();
   private spectators: Set<WebSocket> = new Set();
   private ipBySocket: Map<WebSocket, string> = new Map();
-  private blockedIps: Set<string> = new Set();
+  private blockedEntries: Map<string, { username: string; blockedAt: number }> = new Map();
   private blockedIpsLoaded = false;
 
   constructor(
@@ -44,15 +44,29 @@ export class ChatRoom implements DurableObject {
 
   private async loadBlockedIps(): Promise<void> {
     if (this.blockedIpsLoaded) return;
-    const stored = await this.state.storage.get<string[]>(BLOCKED_IPS_KEY);
-    if (stored) {
-      for (const ip of stored) this.blockedIps.add(ip);
+    const stored = await this.state.storage.get<unknown>(BLOCKED_IPS_KEY);
+    if (Array.isArray(stored)) {
+      for (const entry of stored) {
+        if (typeof entry === "string") {
+          // Old format: plain IP strings
+          this.blockedEntries.set(entry, { username: "unknown", blockedAt: 0 });
+        } else if (entry && typeof entry === "object" && "ip" in entry) {
+          // New format: { ip, username, blockedAt }
+          const e = entry as { ip: string; username: string; blockedAt: number };
+          this.blockedEntries.set(e.ip, { username: e.username, blockedAt: e.blockedAt });
+        }
+      }
     }
     this.blockedIpsLoaded = true;
   }
 
   private async persistBlockedIps(): Promise<void> {
-    await this.state.storage.put(BLOCKED_IPS_KEY, [...this.blockedIps]);
+    const entries = [...this.blockedEntries.entries()].map(([ip, info]) => ({
+      ip,
+      username: info.username,
+      blockedAt: info.blockedAt,
+    }));
+    await this.state.storage.put(BLOCKED_IPS_KEY, entries);
   }
 
   private async getReservation(username: string): Promise<UsernameReservation | undefined> {
@@ -97,7 +111,7 @@ export class ChatRoom implements DurableObject {
 
     server.accept();
 
-    if (this.blockedIps.has(ip)) {
+    if (this.blockedEntries.has(ip)) {
       this.sendBlocked(
         server,
         SERVER_ERROR_CODE.MODERATION_BLOCKED,
@@ -261,7 +275,7 @@ export class ChatRoom implements DurableObject {
       return;
     }
 
-    this.blockedIps.delete(ip);
+    this.blockedEntries.delete(ip);
     this.persistBlockedIps().catch((err) => {
       console.error("[unblock] failed to persist unblock:", err);
     });
@@ -297,7 +311,7 @@ export class ChatRoom implements DurableObject {
 
     if (info.warnings >= MAX_WARNINGS) {
       info.isBlocked = true;
-      this.blockedIps.add(info.ip);
+      this.blockedEntries.set(info.ip, { username: info.username, blockedAt: Date.now() });
       this.persistBlockedIps().catch((err) => {
         console.error("[block] failed to persist blocked IP:", err);
       });

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -5,6 +5,7 @@ import type {
   ChatMessage,
   ClientChatData,
   ClientDeleteData,
+  ClientFlagData,
   ClientJoinData,
   ClientMessage,
   ConnectionInfo,
@@ -162,6 +163,9 @@ export class ChatRoom implements DurableObject {
       case CLIENT_MESSAGE_TYPE.DELETE:
         this.handleDelete(ws, msg.data);
         break;
+      case CLIENT_MESSAGE_TYPE.FLAG:
+        this.handleFlag(ws, msg.data);
+        break;
     }
   }
 
@@ -295,6 +299,49 @@ export class ChatRoom implements DurableObject {
 
     this.messages.splice(idx, 1);
     this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id });
+  }
+
+  private handleFlag(ws: WebSocket, { id }: ClientFlagData): void {
+    const info = this.connections.get(ws);
+    if (!info?.isOwner) return;
+
+    const message = this.messages.find((m) => m.id === id);
+    if (!message) return;
+
+    const targetUsername = message.username;
+
+    // Find the target's IP from their connection
+    let targetIp: string | undefined;
+    for (const [, connInfo] of this.connections) {
+      if (connInfo.username === targetUsername && !connInfo.isOwner) {
+        targetIp = connInfo.ip;
+        break;
+      }
+    }
+
+    if (!targetIp) return;
+
+    // Block the IP
+    this.blockedEntries.set(targetIp, { username: targetUsername, blockedAt: Date.now() });
+    this.persistBlockedIps().catch((err) => {
+      console.error("[flag] failed to persist blocked IP:", err);
+    });
+
+    // Send BLOCKED to all of the target's sockets
+    for (const [targetWs, connInfo] of this.connections) {
+      if (connInfo.ip === targetIp && !connInfo.isOwner) {
+        this.sendBlocked(targetWs, SERVER_ERROR_CODE.MODERATION_BLOCKED, "You have been blocked by the admin.");
+        connInfo.isBlocked = true;
+      }
+    }
+
+    // Respond to admin
+    this.send(ws, {
+      type: SERVER_MESSAGE_TYPE.FLAGGED,
+      username: targetUsername,
+      ip: targetIp,
+      messageId: id,
+    });
   }
 
   // ── Moderation ───────────────────────────────────────────────────────

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -18,14 +18,15 @@ import { CLIENT_MESSAGE_TYPE, SERVER_ERROR_CODE, SERVER_MESSAGE_TYPE } from "./t
 import {
   ADMIN_USERNAME,
   MAX_MESSAGE_LENGTH,
-  MAX_MESSAGES,
   MAX_USERNAME_LENGTH,
+  MESSAGE_RETENTION_MS,
   MAX_WARNINGS,
   MIN_USERNAME_LENGTH,
   RESERVATION_DURATION_MS,
 } from "./config";
 
 const BLOCKED_IPS_KEY = "blockedIps";
+const MESSAGES_KEY = "messages";
 const RESERVATION_PREFIX = "reservation:";
 
 interface UsernameReservation {
@@ -38,12 +39,15 @@ export class ChatRoom implements DurableObject {
   private connections: Map<WebSocket, ConnectionInfo> = new Map();
   private spectators: Set<WebSocket> = new Set();
   private blockedEntries: Map<string, { username: string; blockedAt: number }> = new Map();
+  private messagesLoaded = false;
   private blockedIpsLoaded = false;
 
   constructor(
     private state: DurableObjectState,
     private env: Env,
   ) {}
+
+  // ── Storage: Load ───────────────────────────────────────────────────
 
   private async loadBlockedClients(): Promise<void> {
     if (this.blockedIpsLoaded) return;
@@ -59,13 +63,80 @@ export class ChatRoom implements DurableObject {
     this.blockedIpsLoaded = true;
   }
 
-  private async persistBlockedClients(): Promise<void> {
+  private async loadMessages(): Promise<void> {
+    if (this.messagesLoaded) return;
+    const stored = await this.state.storage.get<ChatMessage[]>(MESSAGES_KEY);
+    if (Array.isArray(stored)) {
+      this.messages = stored;
+    }
+    this.pruneExpiredMessages();
+    this.messagesLoaded = true;
+  }
+
+  // ── Storage: Save (fire-and-forget) ────────────────────────────────
+
+  private saveMessages(): void {
+    this.pruneExpiredMessages();
+    this.state.storage.put(MESSAGES_KEY, this.messages).catch((err) => {
+      console.error("[storage] failed to persist messages:", err);
+    });
+  }
+
+  private saveBlockedClients(): void {
     const entries = [...this.blockedEntries.entries()].map(([clientId, info]) => ({
       clientId,
       username: info.username,
       blockedAt: info.blockedAt,
     }));
-    await this.state.storage.put(BLOCKED_IPS_KEY, entries);
+    this.state.storage.put(BLOCKED_IPS_KEY, entries).catch((err) => {
+      console.error("[storage] failed to persist blocked clients:", err);
+    });
+  }
+
+  private pruneExpiredMessages(): void {
+    const cutoff = Date.now() - MESSAGE_RETENTION_MS;
+    this.messages = this.messages.filter((m) => m.timestamp >= cutoff);
+  }
+
+  // ── Data Mutations (mutate + save) ─────────────────────────────────
+
+  private addMessage(message: ChatMessage): void {
+    this.messages.push(message);
+    this.saveMessages();
+  }
+
+  private removeMessage(id: string): boolean {
+    const idx = this.messages.findIndex((m) => m.id === id);
+    if (idx === -1) return false;
+    this.messages.splice(idx, 1);
+    this.saveMessages();
+    return true;
+  }
+
+  private removeMessagesByClient(clientId: string): ChatMessage[] {
+    const removed = this.messages.filter((m) => m.clientId === clientId);
+    this.messages = this.messages.filter((m) => m.clientId !== clientId);
+    this.saveMessages();
+    return removed;
+  }
+
+  private renameMessagesForClient(clientId: string, newUsername: string): void {
+    for (const msg of this.messages) {
+      if (msg.clientId === clientId) {
+        msg.username = newUsername;
+      }
+    }
+    this.saveMessages();
+  }
+
+  private blockClient(clientId: string, username: string): void {
+    this.blockedEntries.set(clientId, { username, blockedAt: Date.now() });
+    this.saveBlockedClients();
+  }
+
+  private unblockClient(clientId: string): void {
+    this.blockedEntries.delete(clientId);
+    this.saveBlockedClients();
   }
 
   private async getReservation(username: string): Promise<UsernameReservation | undefined> {
@@ -101,6 +172,7 @@ export class ChatRoom implements DurableObject {
     }
 
     await this.loadBlockedClients();
+    await this.loadMessages();
     this.cleanupExpiredReservations().catch((err) => {
       console.error("[reservations] cleanup error:", err);
     });
@@ -225,11 +297,7 @@ export class ChatRoom implements DurableObject {
     const oldUsername = existingConn?.clientId === resolvedClientId ? existingConn.username : undefined;
 
     if (oldUsername != null && oldUsername !== name) {
-      for (const msg of this.messages) {
-        if (msg.clientId === resolvedClientId) {
-          msg.username = name;
-        }
-      }
+      this.renameMessagesForClient(resolvedClientId, name);
       this.broadcast({ type: SERVER_MESSAGE_TYPE.RENAME, oldUsername, newUsername: name });
     }
 
@@ -242,8 +310,9 @@ export class ChatRoom implements DurableObject {
       isBlocked,
     });
 
+    const connInfo = this.connections.get(ws);
     this.send(ws, { type: SERVER_MESSAGE_TYPE.JOINED, isOwner, username: name, isBlocked });
-    this.send(ws, { type: SERVER_MESSAGE_TYPE.HISTORY, messages: this.messages });
+    if (connInfo) this.sendHistory(ws, connInfo);
     this.broadcastStatus();
   }
 
@@ -270,12 +339,8 @@ export class ChatRoom implements DurableObject {
       ...(context?.path && /^\/[-a-z0-9._/]*$/.test(context.path) ? { context } : {}),
     };
 
-    this.messages.push(message);
-    if (this.messages.length > MAX_MESSAGES) {
-      this.messages.shift();
-    }
-
-    this.broadcast(message);
+    this.addMessage(message);
+    this.broadcastMessage(message);
 
     this.moderate(message, ws).catch((err) => {
       console.error("[moderation] unexpected error:", err);
@@ -289,10 +354,7 @@ export class ChatRoom implements DurableObject {
       return;
     }
 
-    this.blockedEntries.delete(clientId);
-    this.persistBlockedClients().catch((err: unknown) => {
-      console.error("[unblock] failed to persist unblock:", err);
-    });
+    this.unblockClient(clientId);
     this.send(ws, { type: SERVER_MESSAGE_TYPE.UNBLOCKED, clientId });
 
     for (const [sock, connInfo] of this.connections) {
@@ -317,10 +379,7 @@ export class ChatRoom implements DurableObject {
     const info = this.connections.get(ws);
     if (!info?.isOwner) return;
 
-    const idx = this.messages.findIndex((m) => m.id === id);
-    if (idx === -1) return;
-
-    this.messages.splice(idx, 1);
+    if (!this.removeMessage(id)) return;
     this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id });
   }
 
@@ -334,10 +393,7 @@ export class ChatRoom implements DurableObject {
     const targetClientId = message.clientId;
     if (!targetClientId) return;
 
-    this.blockedEntries.set(targetClientId, { username: message.username, blockedAt: Date.now() });
-    this.persistBlockedClients().catch((err: unknown) => {
-      console.error("[flag] failed to persist blocked client:", err);
-    });
+    this.blockClient(targetClientId, message.username);
 
     for (const [targetWs, connInfo] of this.connections) {
       if (connInfo.clientId === targetClientId && !connInfo.isOwner) {
@@ -358,10 +414,7 @@ export class ChatRoom implements DurableObject {
     const info = this.connections.get(ws);
     if (!info?.isOwner) return;
 
-    const toRemove = this.messages.filter((m) => m.clientId === targetClientId);
-    this.messages = this.messages.filter((m) => m.clientId !== targetClientId);
-
-    for (const msg of toRemove) {
+    for (const msg of this.removeMessagesByClient(targetClientId)) {
       this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id: msg.id });
     }
   }
@@ -381,7 +434,7 @@ export class ChatRoom implements DurableObject {
     const flagged = result.flagged ?? false;
     if (!flagged) return;
 
-    this.messages = this.messages.filter((m) => m.id !== message.id);
+    this.removeMessage(message.id);
     this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id: message.id });
 
     this.addWarning(senderWs);
@@ -395,10 +448,7 @@ export class ChatRoom implements DurableObject {
 
     if (info.warnings >= MAX_WARNINGS) {
       info.isBlocked = true;
-      this.blockedEntries.set(info.clientId, { username: info.username, blockedAt: Date.now() });
-      this.persistBlockedClients().catch((err: unknown) => {
-        console.error("[block] failed to persist blocked client:", err);
-      });
+      this.blockClient(info.clientId, info.username);
       this.sendBlocked(ws);
     } else {
       const remaining = MAX_WARNINGS - info.warnings;
@@ -473,6 +523,17 @@ export class ChatRoom implements DurableObject {
     }));
   }
 
+  // ── Sanitization ────────────────────────────────────────────────────
+
+  private sanitizeMessage(msg: ChatMessage, viewer: ConnectionInfo): Record<string, unknown> {
+    const isOwn = msg.clientId === viewer.clientId;
+    if (viewer.isOwner) {
+      return { ...msg, isOwn };
+    }
+    const { clientId: _stripped, ...rest } = msg;
+    return { ...rest, isOwn };
+  }
+
   // ── Connection Helpers ───────────────────────────────────────────────
 
   private removeConnection(ws: WebSocket): void {
@@ -510,6 +571,22 @@ export class ChatRoom implements DurableObject {
 
   private sendStatus(ws: WebSocket): void {
     this.send(ws, this.buildStatusMessage());
+  }
+
+  private sendHistory(ws: WebSocket, viewer: ConnectionInfo): void {
+    const messages = this.messages.map((m) => this.sanitizeMessage(m, viewer));
+    ws.send(JSON.stringify({ type: SERVER_MESSAGE_TYPE.HISTORY, messages }));
+  }
+
+  private broadcastMessage(message: ChatMessage): void {
+    for (const [ws, info] of this.connections) {
+      try {
+        ws.send(JSON.stringify(this.sanitizeMessage(message, info)));
+      } catch {
+        this.spectators.delete(ws);
+        this.connections.delete(ws);
+      }
+    }
   }
 
   // ── Broadcast Helpers (all sockets) ──────────────────────────────────

--- a/api/src/chat-room.ts
+++ b/api/src/chat-room.ts
@@ -1,6 +1,7 @@
 import { v7 as uuidv7 } from "uuid";
 import { dispatch } from "./commands";
 import type {
+  BlockedEntry,
   Env,
   ChatMessage,
   ClientChatData,
@@ -465,6 +466,14 @@ export class ChatRoom implements DurableObject {
 
   handleDeleteMessage(ws: WebSocket, messageId: string): void {
     this.handleDelete(ws, { id: messageId });
+  }
+
+  getBlockedEntries(): BlockedEntry[] {
+    return [...this.blockedEntries.entries()].map(([ip, info]) => ({
+      ip,
+      username: info.username,
+      blockedAt: info.blockedAt,
+    }));
   }
 
   // ── Connection Helpers ───────────────────────────────────────────────

--- a/api/src/commands.ts
+++ b/api/src/commands.ts
@@ -40,6 +40,17 @@ register({
   },
 });
 
+register({
+  name: "blocked",
+  description: "List all blocked users and IPs",
+  handler: (ws, _args, chatRoom) => {
+    chatRoom.sendToSocket(ws, {
+      type: SERVER_MESSAGE_TYPE.BLOCKED_LIST,
+      entries: chatRoom.getBlockedEntries(),
+    });
+  },
+});
+
 export function dispatch(text: string, ws: WebSocket, chatRoom: ChatRoom): boolean {
   const match = text.match(/^\/(\S+)\s*(.*)$/);
   if (!match) return false;

--- a/api/src/commands.ts
+++ b/api/src/commands.ts
@@ -1,5 +1,5 @@
 import type { ChatRoom } from "./chat-room";
-import { SERVER_MESSAGE_TYPE } from "./types";
+import { SERVER_MESSAGE_TYPE, SERVER_ERROR_CODE } from "./types";
 
 interface Command {
   name: string;
@@ -28,6 +28,14 @@ register({
   name: "unblock",
   description: "Unblock a user by IP address — /unblock <ip>",
   handler: (ws, args, chatRoom) => {
+    if (!args) {
+      chatRoom.sendToSocket(ws, {
+        type: SERVER_MESSAGE_TYPE.ERROR,
+        code: SERVER_ERROR_CODE.INVALID_MESSAGE,
+        message: "Usage: /unblock <ip>",
+      });
+      return;
+    }
     chatRoom.handleUnblockCommand(ws, args);
   },
 });

--- a/api/src/commands.ts
+++ b/api/src/commands.ts
@@ -26,7 +26,7 @@ register({
 
 register({
   name: "blocked",
-  description: "List all blocked users and IPs",
+  description: "List all blocked users",
   handler: (ws, _args, chatRoom) => {
     chatRoom.sendToSocket(ws, {
       type: SERVER_MESSAGE_TYPE.BLOCKED_LIST,

--- a/api/src/commands.ts
+++ b/api/src/commands.ts
@@ -35,6 +35,14 @@ register({
   },
 });
 
+register({
+  name: "clear",
+  description: "Clear all chat messages (keeps users & blocked list)",
+  handler: (_ws, _args, chatRoom) => {
+    chatRoom.clearMessages();
+  },
+});
+
 export function dispatch(text: string, ws: WebSocket, chatRoom: ChatRoom): boolean {
   const match = text.match(/^\/(\S+)\s*(.*)$/);
   if (!match) return false;

--- a/api/src/commands.ts
+++ b/api/src/commands.ts
@@ -1,5 +1,5 @@
 import type { ChatRoom } from "./chat-room";
-import { SERVER_MESSAGE_TYPE, SERVER_ERROR_CODE } from "./types";
+import { SERVER_MESSAGE_TYPE } from "./types";
 
 interface Command {
   name: string;
@@ -21,22 +21,6 @@ register({
       type: SERVER_MESSAGE_TYPE.HELP,
       commands: commands.map(({ name, description }) => ({ name, description })),
     });
-  },
-});
-
-register({
-  name: "unblock",
-  description: "Unblock a user by IP address — /unblock <ip>",
-  handler: (ws, args, chatRoom) => {
-    if (!args) {
-      chatRoom.sendToSocket(ws, {
-        type: SERVER_MESSAGE_TYPE.ERROR,
-        code: SERVER_ERROR_CODE.INVALID_MESSAGE,
-        message: "Usage: /unblock <ip>",
-      });
-      return;
-    }
-    chatRoom.handleUnblockCommand(ws, args);
   },
 });
 

--- a/api/src/commands.ts
+++ b/api/src/commands.ts
@@ -1,0 +1,45 @@
+import type { ChatRoom } from "./chat-room";
+import { SERVER_MESSAGE_TYPE } from "./types";
+
+interface Command {
+  name: string;
+  description: string;
+  handler: (ws: WebSocket, args: string, chatRoom: ChatRoom) => void;
+}
+
+const commands: Command[] = [];
+
+function register(command: Command): void {
+  commands.push(command);
+}
+
+register({
+  name: "help",
+  description: "Show this help message",
+  handler: (ws, _args, chatRoom) => {
+    chatRoom.sendToSocket(ws, {
+      type: SERVER_MESSAGE_TYPE.HELP,
+      commands: commands.map(({ name, description }) => ({ name, description })),
+    });
+  },
+});
+
+register({
+  name: "unblock",
+  description: "Unblock a user by IP address — /unblock <ip>",
+  handler: (ws, args, chatRoom) => {
+    chatRoom.handleUnblockCommand(ws, args);
+  },
+});
+
+export function dispatch(text: string, ws: WebSocket, chatRoom: ChatRoom): boolean {
+  const match = text.match(/^\/(\S+)\s*(.*)$/);
+  if (!match) return false;
+
+  const [, name, args] = match;
+  const command = commands.find((c) => c.name === name);
+  if (!command) return false;
+
+  command.handler(ws, args.trim(), chatRoom);
+  return true;
+}

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -1,4 +1,4 @@
-export const MAX_MESSAGES = 50;
+export const MESSAGE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 export const MAX_WARNINGS = 3;
 export const ADMIN_USERNAME = "thalida";
 export const RESERVATION_DURATION_MS = 30 * 24 * 60 * 60 * 1000;

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -5,3 +5,80 @@ export const RESERVATION_DURATION_MS = 30 * 24 * 60 * 60 * 1000;
 export const MAX_MESSAGE_LENGTH = 500;
 export const MIN_USERNAME_LENGTH = 2;
 export const MAX_USERNAME_LENGTH = 20;
+
+export const COLORS = [
+  "red",
+  "blue",
+  "gold",
+  "pink",
+  "jade",
+  "teal",
+  "gray",
+  "mint",
+  "plum",
+  "sage",
+  "rust",
+  "lime",
+  "navy",
+  "wine",
+  "rose",
+  "onyx",
+  "aqua",
+  "sand",
+  "dusk",
+  "dawn",
+  "coal",
+  "snow",
+  "iris",
+  "opal",
+  "ruby",
+  "buff",
+  "tan",
+  "ash",
+  "fawn",
+  "coral",
+];
+
+export const ANIMALS = [
+  "fox",
+  "owl",
+  "cat",
+  "bat",
+  "bee",
+  "elk",
+  "emu",
+  "hen",
+  "jay",
+  "koi",
+  "ram",
+  "yak",
+  "ape",
+  "ant",
+  "pup",
+  "bug",
+  "gnu",
+  "hawk",
+  "lynx",
+  "newt",
+  "orca",
+  "puma",
+  "seal",
+  "wolf",
+  "bear",
+  "crow",
+  "deer",
+  "duck",
+  "frog",
+  "hare",
+  "lark",
+  "lion",
+  "moth",
+  "swan",
+  "wren",
+];
+
+export function generateRandomUsername(): string {
+  const color = COLORS[Math.floor(Math.random() * COLORS.length)];
+  const animal = ANIMALS[Math.floor(Math.random() * ANIMALS.length)];
+  return `${color}-${animal}`;
+}

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -26,6 +26,7 @@ export interface ConnectionInfo {
 
 export const CLIENT_MESSAGE_TYPE = {
   JOIN: "join",
+  RENAME: "rename",
   MESSAGE: "message",
   DELETE: "delete",
   FLAG: "flag",
@@ -36,7 +37,6 @@ export const CLIENT_MESSAGE_TYPE = {
 export type ClientMessageType = (typeof CLIENT_MESSAGE_TYPE)[keyof typeof CLIENT_MESSAGE_TYPE];
 
 export interface ClientJoinData {
-  username: string;
   token?: string;
   clientId?: string;
 }
@@ -62,8 +62,13 @@ export interface ClientUnblockData {
   clientId: string;
 }
 
+export interface ClientRenameData {
+  username: string;
+}
+
 export type ClientMessage =
   | { type: "join"; data: ClientJoinData }
+  | { type: "rename"; data: ClientRenameData }
   | { type: "message"; data: ClientChatData }
   | { type: "delete"; data: ClientDeleteData }
   | { type: "flag"; data: ClientFlagData }

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -30,6 +30,7 @@ export const CLIENT_MESSAGE_TYPE = {
   DELETE: "delete",
   FLAG: "flag",
   DELETE_BY_USER: "delete_by_user",
+  UNBLOCK: "unblock",
 } as const;
 
 export type ClientMessageType = (typeof CLIENT_MESSAGE_TYPE)[keyof typeof CLIENT_MESSAGE_TYPE];
@@ -57,12 +58,17 @@ export interface ClientDeleteByUserData {
   username: string;
 }
 
+export interface ClientUnblockData {
+  ip: string;
+}
+
 export type ClientMessage =
   | { type: "join"; data: ClientJoinData }
   | { type: "message"; data: ClientChatData }
   | { type: "delete"; data: ClientDeleteData }
   | { type: "flag"; data: ClientFlagData }
-  | { type: "delete_by_user"; data: ClientDeleteByUserData };
+  | { type: "delete_by_user"; data: ClientDeleteByUserData }
+  | { type: "unblock"; data: ClientUnblockData };
 
 // ── Server → Client ─────────────────────────────────────────────────
 
@@ -99,6 +105,7 @@ export const SERVER_ERROR_CODE = {
   MODERATION_WARNING: "moderation_warning",
   MODERATION_BLOCKED: "moderation_blocked",
   UNAUTHORIZED: "unauthorized",
+  UNBLOCKED: "unblocked",
 } as const;
 
 export type ServerErrorCode = (typeof SERVER_ERROR_CODE)[keyof typeof SERVER_ERROR_CODE];
@@ -139,6 +146,7 @@ export interface ServerJoinedMessage {
   type: "joined";
   isOwner: boolean;
   username: string;
+  isBlocked: boolean;
 }
 
 // ── Server → Client: Admin Responses ─────────────────────────────────

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -27,6 +27,9 @@ export interface ConnectionInfo {
 export const CLIENT_MESSAGE_TYPE = {
   JOIN: "join",
   MESSAGE: "message",
+  DELETE: "delete",
+  FLAG: "flag",
+  DELETE_BY_USER: "delete_by_user",
 } as const;
 
 export type ClientMessageType = (typeof CLIENT_MESSAGE_TYPE)[keyof typeof CLIENT_MESSAGE_TYPE];
@@ -42,7 +45,24 @@ export interface ClientChatData {
   context?: MessageContext;
 }
 
-export type ClientMessage = { type: "join"; data: ClientJoinData } | { type: "message"; data: ClientChatData };
+export interface ClientDeleteData {
+  id: string;
+}
+
+export interface ClientFlagData {
+  id: string;
+}
+
+export interface ClientDeleteByUserData {
+  username: string;
+}
+
+export type ClientMessage =
+  | { type: "join"; data: ClientJoinData }
+  | { type: "message"; data: ClientChatData }
+  | { type: "delete"; data: ClientDeleteData }
+  | { type: "flag"; data: ClientFlagData }
+  | { type: "delete_by_user"; data: ClientDeleteByUserData };
 
 // ── Server → Client ─────────────────────────────────────────────────
 
@@ -52,6 +72,8 @@ export const SERVER_MESSAGE_TYPE = {
   BLOCKED: "blocked",
   UNBLOCKED: "unblocked",
   HELP: "help",
+  FLAGGED: "flagged",
+  BLOCKED_LIST: "blocked_list",
   JOINED: "joined",
   STATUS: "status",
   HISTORY: "history",
@@ -131,6 +153,24 @@ export interface ServerHelpMessage {
   commands: Array<{ name: string; description: string }>;
 }
 
+export interface ServerFlaggedMessage {
+  type: "flagged";
+  username: string;
+  ip: string;
+  messageId: string;
+}
+
+export interface BlockedEntry {
+  ip: string;
+  username: string;
+  blockedAt: number;
+}
+
+export interface ServerBlockedListMessage {
+  type: "blocked_list";
+  entries: BlockedEntry[];
+}
+
 // ── Combined Server Message ─────────────────────────────────────────
 
 export type ServerMessage =
@@ -139,6 +179,8 @@ export type ServerMessage =
   | ServerJoinedMessage
   | ServerUnblockedMessage
   | ServerHelpMessage
+  | ServerFlaggedMessage
+  | ServerBlockedListMessage
   | ChatMessage;
 
 // ── API Types ───────────────────────────────────────────────────────

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -7,6 +7,7 @@ export interface MessageContext {
 export interface ChatMessage {
   type: "message";
   id: string;
+  clientId: string;
   username: string;
   text: string;
   timestamp: number;
@@ -14,12 +15,11 @@ export interface ChatMessage {
 }
 
 export interface ConnectionInfo {
-  ip: string;
+  clientId: string;
   username: string;
   isOwner: boolean;
   warnings: number;
   isBlocked: boolean;
-  clientId?: string;
 }
 
 // ── Client → Server ─────────────────────────────────────────────────
@@ -55,11 +55,11 @@ export interface ClientFlagData {
 }
 
 export interface ClientDeleteByUserData {
-  username: string;
+  clientId: string;
 }
 
 export interface ClientUnblockData {
-  ip: string;
+  clientId: string;
 }
 
 export type ClientMessage =
@@ -85,6 +85,7 @@ export const SERVER_MESSAGE_TYPE = {
   HISTORY: "history",
   REMOVE: "remove",
   MESSAGE: "message",
+  RENAME: "rename",
 } as const;
 
 export type ServerMessageType = (typeof SERVER_MESSAGE_TYPE)[keyof typeof SERVER_MESSAGE_TYPE];
@@ -153,7 +154,7 @@ export interface ServerJoinedMessage {
 
 export interface ServerUnblockedMessage {
   type: "unblocked";
-  ip: string;
+  clientId: string;
 }
 
 export interface ServerHelpMessage {
@@ -164,12 +165,18 @@ export interface ServerHelpMessage {
 export interface ServerFlaggedMessage {
   type: "flagged";
   username: string;
-  ip: string;
+  clientId: string;
   messageId: string;
 }
 
+export interface ServerRenameMessage {
+  type: "rename";
+  oldUsername: string;
+  newUsername: string;
+}
+
 export interface BlockedEntry {
-  ip: string;
+  clientId: string;
   username: string;
   blockedAt: number;
 }
@@ -188,6 +195,7 @@ export type ServerMessage =
   | ServerUnblockedMessage
   | ServerHelpMessage
   | ServerFlaggedMessage
+  | ServerRenameMessage
   | ServerBlockedListMessage
   | ChatMessage;
 

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -51,6 +51,7 @@ export const SERVER_MESSAGE_TYPE = {
   WARNING: "warning",
   BLOCKED: "blocked",
   UNBLOCKED: "unblocked",
+  HELP: "help",
   JOINED: "joined",
   STATUS: "status",
   HISTORY: "history",
@@ -125,6 +126,11 @@ export interface ServerUnblockedMessage {
   ip: string;
 }
 
+export interface ServerHelpMessage {
+  type: "help";
+  commands: Array<{ name: string; description: string }>;
+}
+
 // ── Combined Server Message ─────────────────────────────────────────
 
 export type ServerMessage =
@@ -132,6 +138,7 @@ export type ServerMessage =
   | ServerBroadcast
   | ServerJoinedMessage
   | ServerUnblockedMessage
+  | ServerHelpMessage
   | ChatMessage;
 
 // ── API Types ───────────────────────────────────────────────────────

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -129,6 +129,7 @@ export interface ServerBroadcastStatusMessage {
   type: "status";
   isOwnerOnline: boolean;
   userCount: number;
+  onlineUsernames: string[];
 }
 
 export interface ServerBroadcastHistoryMessage {

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -56,33 +56,39 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
 
 <template id="chat-msg-tpl">
   <div class="group mb-2" data-msg-id="">
-    <div class="flex items-baseline gap-1.5 text-xs leading-tight">
-      <span data-chat="username" class="font-semibold text-teal data-admin:text-neon"></span>
-      <span class="ml-auto flex items-baseline gap-1.5 whitespace-nowrap">
-        <span data-chat="admin-controls" hidden class="inline-flex gap-1">
-          <button
-            data-chat="delete-btn"
-            class="text-muted hover:text-red-400 transition-colors"
-            type="button"
-            title="Delete message"
-          >
-            <i class="fa-solid fa-trash-can fa-xs" aria-hidden="true"></i>
-          </button>
+    <div class="flex gap-1.5">
+      <div class="flex-1 min-w-0">
+        <div class="flex items-baseline gap-1 text-xs leading-tight">
+          <span data-chat="username" class="font-semibold text-teal data-admin:text-neon shrink-0"></span>
+          <span data-chat="at-sep" hidden class="opacity-40 shrink-0">@</span>
+          <a data-chat="page" hidden class="text-muted hover:text-teal truncate min-w-0" href=""></a>
+        </div>
+        <div data-chat="text" class="text-sm"></div>
+      </div>
+      <div class="flex flex-col items-end shrink-0 text-xs leading-tight">
+        <span class="flex items-center gap-1">
+          <span data-chat="time" class="opacity-40 whitespace-nowrap"></span>
           <button
             data-chat="flag-btn"
-            class="text-muted hover:text-yellow-400 transition-colors"
+            hidden
+            class="text-muted hover:text-yellow-400 transition-colors leading-none"
             type="button"
             title="Flag & ban user"
           >
-            <i class="fa-solid fa-flag fa-xs" aria-hidden="true"></i>
+            <i class="fa-solid fa-flag fa-2xs" aria-hidden="true"></i>
           </button>
         </span>
-        <a data-chat="page" hidden class="text-text font-medium underline hover:text-teal" href=""></a>
-        <span data-chat="sep" hidden class="opacity-40">·</span>
-        <span data-chat="time" class="opacity-40"></span>
-      </span>
+        <button
+          data-chat="delete-btn"
+          hidden
+          class="text-muted hover:text-red-400 transition-colors leading-none self-end"
+          type="button"
+          title="Delete message"
+        >
+          <i class="fa-solid fa-trash-can fa-2xs" aria-hidden="true"></i>
+        </button>
+      </div>
     </div>
-    <div data-chat="text"></div>
   </div>
 </template>
 

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -63,7 +63,8 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
 <template id="chat-msg-tpl">
   <div class="group mb-2" data-msg-id="">
     <div class="flex items-baseline gap-1 text-xs leading-tight">
-      <span data-chat="username" class="font-semibold text-neon data-admin:text-admin shrink-0"></span>
+      <span data-chat="username" class="font-semibold text-neon data-admin:text-admin data-own:text-accent shrink-0"
+      ></span>
       <span data-chat="at-sep" hidden class="opacity-40 shrink-0">@</span>
       <a data-chat="page" hidden class="text-muted hover:text-teal truncate min-w-0" href=""></a>
       <span class="flex-1"></span>
@@ -125,8 +126,5 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
   }
   [data-chat="flag-btn"][data-confirm] {
     color: var(--color-yellow-400, #facc15);
-  }
-  [data-own] [data-chat="username"] {
-    color: var(--color-accent);
   }
 </style>

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -14,7 +14,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
         <span
           id="js-chat-status-dot"
           class="inline-block shrink-0 w-1.5 h-1.5 rounded-full bg-muted data-[online=true]:bg-neon"></span>
-        <span id="js-chat-owner-status" class="data-[online=true]:text-neon">offline</span>
+        <span id="js-chat-owner-status" class="data-[online=true]:text-admin">offline</span>
       </span>
       <span class="opacity-30">·</span>
       <span id="js-chat-user-count" title="0 online"
@@ -63,7 +63,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
 <template id="chat-msg-tpl">
   <div class="group mb-2" data-msg-id="">
     <div class="flex items-baseline gap-1 text-xs leading-tight">
-      <span data-chat="username" class="font-semibold text-teal data-admin:text-neon shrink-0"></span>
+      <span data-chat="username" class="font-semibold text-neon data-admin:text-admin shrink-0"></span>
       <span data-chat="at-sep" hidden class="opacity-40 shrink-0">@</span>
       <a data-chat="page" hidden class="text-muted hover:text-teal truncate min-w-0" href=""></a>
       <span class="flex-1"></span>

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -13,7 +13,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
       <span class="flex items-center gap-1" id="js-chat-owner-wrap" title="Site owner: offline">
         <span
           id="js-chat-status-dot"
-          class="inline-block shrink-0 w-1.5 h-1.5 rounded-full bg-muted data-[online=true]:bg-neon"></span>
+          class="inline-block self-center shrink-0 w-1.5 h-1.5 rounded-full bg-muted/50 data-online:bg-neon/70"></span>
         <span id="js-chat-owner-status" class="text-admin">offline</span>
       </span>
       <span class="opacity-30">·</span>
@@ -26,7 +26,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
     </button>
   </div>
 
-  <div class="flex flex-col gap-2 flex-1 min-h-0 p-4">
+  <div class="flex flex-col gap-2 flex-1 min-h-0 px-2.5 py-3">
     <div id="js-chat-messages" class="flex-1 text-sm text-text overflow-y-auto min-h-0"></div>
     <div id="js-chat-username-row" class="flex items-center gap-1.5">
       <label for="chat-username" class="whitespace-nowrap uppercase tracking-widest font-body text-2xs text-muted">
@@ -62,8 +62,11 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
 
 <template id="chat-msg-tpl">
   <div class="group mb-2" data-msg-id="">
-    <div class="flex items-baseline gap-1 text-xs leading-tight">
-      <span data-chat="username" class="font-semibold text-neon data-admin:text-admin data-own:text-accent shrink-0"
+    <div class="flex items-baseline gap-1.5 text-xs leading-tight">
+      <span
+        data-chat="status-dot"
+        class="inline-block self-center shrink-0 w-1.5 h-1.5 rounded-full bg-muted/50 data-online:bg-neon/70"></span>
+      <span data-chat="username" class="font-semibold text-teal data-admin:text-admin data-own:text-accent shrink-0"
       ></span>
       <span data-chat="at-sep" hidden class="opacity-40 shrink-0">@</span>
       <a data-chat="page" hidden class="text-muted hover:text-teal truncate min-w-0" href=""></a>
@@ -88,7 +91,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
         <i class="fa-solid fa-trash-can fa-xs" aria-hidden="true"></i>
       </button>
     </div>
-    <div data-chat="text" class="text-sm whitespace-pre-line hyphens-auto wrap-break-word"></div>
+    <div data-chat="text" class="mt-0.5 text-sm whitespace-pre-line hyphens-auto wrap-break-word"></div>
   </div>
 </template>
 

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -14,7 +14,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
         <span
           id="js-chat-status-dot"
           class="inline-block shrink-0 w-1.5 h-1.5 rounded-full bg-muted data-[online=true]:bg-neon"></span>
-        <span id="js-chat-owner-status" class="data-[online=true]:text-admin">offline</span>
+        <span id="js-chat-owner-status" class="text-admin">offline</span>
       </span>
       <span class="opacity-30">·</span>
       <span id="js-chat-user-count" title="0 online"

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -93,6 +93,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
       <span class="ml-auto opacity-40" data-chat="notice-time"></span>
     </div>
     <div data-chat="notice-text" class="mt-0.5 text-muted whitespace-pre-line"></div>
+    <div data-chat="notice-actions" hidden class="mt-0.5 flex items-baseline gap-1.5 text-muted"></div>
   </div>
 </template>
 

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -55,10 +55,28 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
 </aside>
 
 <template id="chat-msg-tpl">
-  <div class="mb-2" data-msg-id="">
+  <div class="group mb-2" data-msg-id="">
     <div class="flex items-baseline gap-1.5 text-xs leading-tight">
       <span data-chat="username" class="font-semibold text-teal data-admin:text-neon"></span>
       <span class="ml-auto flex items-baseline gap-1.5 whitespace-nowrap">
+        <span data-chat="admin-controls" hidden class="inline-flex gap-1">
+          <button
+            data-chat="delete-btn"
+            class="text-muted hover:text-red-400 transition-colors"
+            type="button"
+            title="Delete message"
+          >
+            <i class="fa-solid fa-trash-can fa-xs" aria-hidden="true"></i>
+          </button>
+          <button
+            data-chat="flag-btn"
+            class="text-muted hover:text-orange-400 transition-colors"
+            type="button"
+            title="Flag & ban user"
+          >
+            <i class="fa-solid fa-flag fa-xs" aria-hidden="true"></i>
+          </button>
+        </span>
         <a data-chat="page" hidden class="text-text font-medium underline hover:text-teal" href=""></a>
         <span data-chat="sep" hidden class="opacity-40">·</span>
         <span data-chat="time" class="opacity-40"></span>
@@ -69,7 +87,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
 </template>
 
 <template id="chat-notice-tpl">
-  <div class="italic"></div>
+  <div class="italic whitespace-pre-line"></div>
 </template>
 
 <meta name="chat-ws-url" content={wsUrl} />
@@ -89,5 +107,11 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
   #chat-username:read-only {
     border-bottom: none;
     cursor: default;
+  }
+  [data-chat="delete-btn"][data-confirm] {
+    color: var(--color-red-400, #f87171);
+  }
+  [data-chat="flag-btn"][data-confirm] {
+    color: var(--color-orange-400, #fb923c);
   }
 </style>

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -75,7 +75,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
             type="button"
             title="Flag & ban user"
           >
-            <i class="fa-solid fa-flag fa-2xs" aria-hidden="true"></i>
+            <i class="fa-solid fa-flag fa-xs" aria-hidden="true"></i>
           </button>
         </span>
         <button
@@ -85,7 +85,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
           type="button"
           title="Delete message"
         >
-          <i class="fa-solid fa-trash-can fa-2xs" aria-hidden="true"></i>
+          <i class="fa-solid fa-trash-can fa-xs" aria-hidden="true"></i>
         </button>
       </div>
     </div>

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -8,13 +8,19 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
   transition:persist="chat"
 >
   <div class="flex items-center gap-1.5 h-12 px-3 bg-midnight border-b border-border shrink-0">
-    <h2 class="m-0 font-heading text-base font-semibold text-text tracking-tight">Chat</h2>
-    <span id="js-chat-status-dot" class="inline-block shrink-0 w-2 h-2 rounded-full bg-muted data-[online=true]:bg-neon"
-    ></span>
-    <span id="js-chat-owner-status" class="flex-1 text-xs text-muted data-[online=true]:text-neon">offline</span>
-    <span id="js-chat-user-count" class="text-xs text-muted" title="0 online"
-      ><i class="fa-solid fa-users"></i> <span data-chat="viewer-count">0 online</span></span
-    >
+    <h2 class="m-0 font-heading text-base font-semibold text-text tracking-tight flex-1">Chat</h2>
+    <span class="flex items-center gap-1.5 text-xs text-muted">
+      <span class="flex items-center gap-1" id="js-chat-owner-wrap" title="Site owner: offline">
+        <span
+          id="js-chat-status-dot"
+          class="inline-block shrink-0 w-1.5 h-1.5 rounded-full bg-muted data-[online=true]:bg-neon"></span>
+        <span id="js-chat-owner-status" class="data-[online=true]:text-neon">offline</span>
+      </span>
+      <span class="opacity-30">·</span>
+      <span id="js-chat-user-count" title="0 online"
+        ><i class="fa-solid fa-users"></i> <span data-chat="viewer-count">0</span></span
+      >
+    </span>
     <button id="chat-overlay-close" class="hidden" type="button" aria-label="Close chat">
       <i class="fa-solid fa-xmark" aria-hidden="true"></i>
     </button>

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -62,39 +62,32 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
 
 <template id="chat-msg-tpl">
   <div class="group mb-2" data-msg-id="">
-    <div class="flex gap-1.5">
-      <div class="flex-1 min-w-0">
-        <div class="flex items-baseline gap-1 text-xs leading-tight">
-          <span data-chat="username" class="font-semibold text-teal data-admin:text-neon shrink-0"></span>
-          <span data-chat="at-sep" hidden class="opacity-40 shrink-0">@</span>
-          <a data-chat="page" hidden class="text-muted hover:text-teal truncate min-w-0" href=""></a>
-        </div>
-        <div data-chat="text" class="text-sm"></div>
-      </div>
-      <div class="flex flex-col items-end shrink-0 text-xs leading-tight">
-        <span class="flex items-center gap-1">
-          <span data-chat="time" class="opacity-40 whitespace-nowrap"></span>
-          <button
-            data-chat="flag-btn"
-            hidden
-            class="text-muted hover:text-yellow-400 transition-colors leading-none"
-            type="button"
-            title="Flag & ban user"
-          >
-            <i class="fa-solid fa-flag fa-xs" aria-hidden="true"></i>
-          </button>
-        </span>
-        <button
-          data-chat="delete-btn"
-          hidden
-          class="text-muted hover:text-red-400 transition-colors leading-none self-end"
-          type="button"
-          title="Delete message"
-        >
-          <i class="fa-solid fa-trash-can fa-xs" aria-hidden="true"></i>
-        </button>
-      </div>
+    <div class="flex items-baseline gap-1 text-xs leading-tight">
+      <span data-chat="username" class="font-semibold text-teal data-admin:text-neon shrink-0"></span>
+      <span data-chat="at-sep" hidden class="opacity-40 shrink-0">@</span>
+      <a data-chat="page" hidden class="text-muted hover:text-teal truncate min-w-0" href=""></a>
+      <span class="flex-1"></span>
+      <span data-chat="time" class="opacity-40 whitespace-nowrap"></span>
+      <button
+        data-chat="flag-btn"
+        hidden
+        class="text-muted hover:text-yellow-400 transition-colors leading-none"
+        type="button"
+        title="Flag & ban user"
+      >
+        <i class="fa-solid fa-flag fa-xs" aria-hidden="true"></i>
+      </button>
+      <button
+        data-chat="delete-btn"
+        hidden
+        class="text-muted hover:text-red-400 transition-colors leading-none"
+        type="button"
+        title="Delete message"
+      >
+        <i class="fa-solid fa-trash-can fa-xs" aria-hidden="true"></i>
+      </button>
     </div>
+    <div data-chat="text" class="text-sm whitespace-pre-line hyphens-auto wrap-break-word"></div>
   </div>
 </template>
 

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -22,7 +22,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
 
   <div class="flex flex-col gap-2 flex-1 min-h-0 p-4">
     <div id="js-chat-messages" class="flex-1 text-sm text-text overflow-y-auto min-h-0"></div>
-    <div class="flex items-center gap-1.5">
+    <div id="js-chat-username-row" class="flex items-center gap-1.5">
       <label for="chat-username" class="whitespace-nowrap uppercase tracking-widest font-body text-2xs text-muted">
         chatting as
       </label>
@@ -70,7 +70,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
           </button>
           <button
             data-chat="flag-btn"
-            class="text-muted hover:text-orange-400 transition-colors"
+            class="text-muted hover:text-yellow-400 transition-colors"
             type="button"
             title="Flag & ban user"
           >
@@ -87,7 +87,13 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
 </template>
 
 <template id="chat-notice-tpl">
-  <div class="italic whitespace-pre-line"></div>
+  <div class="mb-2">
+    <div class="flex items-baseline gap-1.5 text-xs leading-tight">
+      <span class="font-semibold text-muted">system</span>
+      <span class="ml-auto opacity-40" data-chat="notice-time"></span>
+    </div>
+    <div data-chat="notice-text" class="mt-0.5 text-muted whitespace-pre-line"></div>
+  </div>
 </template>
 
 <meta name="chat-ws-url" content={wsUrl} />
@@ -112,6 +118,6 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
     color: var(--color-red-400, #f87171);
   }
   [data-chat="flag-btn"][data-confirm] {
-    color: var(--color-orange-400, #fb923c);
+    color: var(--color-yellow-400, #facc15);
   }
 </style>

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -12,8 +12,8 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
     <span id="js-chat-status-dot" class="inline-block shrink-0 w-2 h-2 rounded-full bg-muted data-[online=true]:bg-neon"
     ></span>
     <span id="js-chat-owner-status" class="flex-1 text-xs text-muted data-[online=true]:text-neon">offline</span>
-    <span id="js-chat-user-count" class="text-xs text-muted" title="0 viewers"
-      ><i class="fa-solid fa-eye"></i> <span data-chat="viewer-count">0 viewers</span></span
+    <span id="js-chat-user-count" class="text-xs text-muted" title="0 online"
+      ><i class="fa-solid fa-users"></i> <span data-chat="viewer-count">0 online</span></span
     >
     <button id="chat-overlay-close" class="hidden" type="button" aria-label="Close chat">
       <i class="fa-solid fa-xmark" aria-hidden="true"></i>

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -126,4 +126,7 @@ const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
   [data-chat="flag-btn"][data-confirm] {
     color: var(--color-yellow-400, #facc15);
   }
+  [data-own] [data-chat="username"] {
+    color: var(--color-accent);
+  }
 </style>

--- a/app/src/components/Chat/__tests__/chat-render.test.ts
+++ b/app/src/components/Chat/__tests__/chat-render.test.ts
@@ -41,16 +41,16 @@ describe("truncateMiddle", () => {
 // -- formatMessageTime -------------------------------------------------------
 
 describe("formatMessageTime", () => {
-  it("returns time only for today's messages", () => {
+  it("returns time only for messages within 24 hours", () => {
     const now = Date.now();
     const result = formatMessageTime(now);
     // Should NOT contain a month abbreviation
     expect(result).not.toMatch(/Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/);
   });
 
-  it("includes date for messages from a different day", () => {
-    const yesterday = Date.now() - 2 * 24 * 60 * 60 * 1000;
-    const result = formatMessageTime(yesterday);
+  it("includes date for messages older than 24 hours", () => {
+    const overADay = Date.now() - 25 * 60 * 60 * 1000;
+    const result = formatMessageTime(overADay);
     // Should contain a month abbreviation
     expect(result).toMatch(/Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/);
   });

--- a/app/src/components/Chat/__tests__/chat-render.test.ts
+++ b/app/src/components/Chat/__tests__/chat-render.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { truncateMiddle, formatMessageTime, renderNotice } from "@components/Chat/chat-render";
+
+// -- truncateMiddle ----------------------------------------------------------
+
+describe("truncateMiddle", () => {
+  it("returns short paths unchanged", () => {
+    expect(truncateMiddle("/about", 25)).toBe("/about");
+  });
+
+  it("returns paths at exactly maxLen unchanged", () => {
+    const path = "/a".repeat(12) + "/b";
+    expect(truncateMiddle(path, path.length)).toBe(path);
+  });
+
+  it("truncates long paths with ellipsis in the middle", () => {
+    const result = truncateMiddle("/projects/some-really-long-project/deeply/nested/page", 25);
+    expect(result).toContain("/\u2026/");
+    expect(result.length).toBeLessThanOrEqual(25);
+  });
+
+  it("preserves leading slash", () => {
+    const result = truncateMiddle("/very/long/deeply/nested/path/to/page", 20);
+    expect(result.startsWith("/")).toBe(true);
+  });
+
+  it("preserves trailing segment when possible", () => {
+    const result = truncateMiddle("/a/b/c/d/e/page", 20);
+    expect(result).toContain("page");
+  });
+
+  it("handles root path", () => {
+    expect(truncateMiddle("/", 25)).toBe("/");
+  });
+
+  it("handles single-segment paths", () => {
+    expect(truncateMiddle("/about", 3)).toContain("/\u2026/");
+  });
+});
+
+// -- formatMessageTime -------------------------------------------------------
+
+describe("formatMessageTime", () => {
+  it("returns time only for today's messages", () => {
+    const now = Date.now();
+    const result = formatMessageTime(now);
+    // Should NOT contain a month abbreviation
+    expect(result).not.toMatch(/Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/);
+  });
+
+  it("includes date for messages from a different day", () => {
+    const yesterday = Date.now() - 2 * 24 * 60 * 60 * 1000;
+    const result = formatMessageTime(yesterday);
+    // Should contain a month abbreviation
+    expect(result).toMatch(/Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/);
+  });
+});
+
+// -- renderNotice ------------------------------------------------------------
+
+function createNoticeTemplate(): HTMLTemplateElement {
+  const tpl = document.createElement("template");
+  tpl.innerHTML = `
+    <div class="mb-2">
+      <div class="flex items-baseline gap-1.5 text-xs leading-tight">
+        <span class="font-semibold text-muted">system</span>
+        <span class="ml-auto opacity-40" data-chat="notice-time"></span>
+      </div>
+      <div data-chat="notice-text" class="mt-0.5 text-muted whitespace-pre-line"></div>
+      <div data-chat="notice-actions" hidden class="mt-0.5 flex items-baseline gap-1.5 text-muted"></div>
+    </div>
+  `;
+  return tpl;
+}
+
+describe("renderNotice", () => {
+  let tpl: HTMLTemplateElement;
+
+  beforeEach(() => {
+    tpl = createNoticeTemplate();
+  });
+
+  it("sets the notice text", () => {
+    const el = renderNotice(tpl, "Hello world");
+    const textEl = el.querySelector('[data-chat="notice-text"]') as HTMLElement;
+    expect(textEl.textContent).toBe("Hello world");
+  });
+
+  it("sets the time", () => {
+    const el = renderNotice(tpl, "test");
+    const timeEl = el.querySelector('[data-chat="notice-time"]') as HTMLElement;
+    expect(timeEl.textContent).not.toBe("");
+  });
+
+  it("hides actions container when no actions provided", () => {
+    const el = renderNotice(tpl, "test");
+    const actionsEl = el.querySelector('[data-chat="notice-actions"]') as HTMLElement;
+    expect(actionsEl.hidden).toBe(true);
+  });
+
+  it("shows actions container when actions are provided", () => {
+    const el = renderNotice(tpl, "test", [{ label: "ok", action: () => {} }]);
+    const actionsEl = el.querySelector('[data-chat="notice-actions"]') as HTMLElement;
+    expect(actionsEl.hidden).toBe(false);
+  });
+
+  it("renders action labels in brackets", () => {
+    const el = renderNotice(tpl, "test", [
+      { label: "unblock", action: () => {} },
+      { label: "ignore", action: () => {} },
+    ]);
+    const actionsEl = el.querySelector('[data-chat="notice-actions"]') as HTMLElement;
+    const spans = actionsEl.querySelectorAll("span");
+    expect(spans[0].textContent).toBe("[unblock]");
+    expect(spans[1].textContent).toBe("[ignore]");
+  });
+
+  it("calls the action callback when an action button is clicked", () => {
+    const callback = vi.fn();
+    const el = renderNotice(tpl, "Blocked user", [{ label: "unblock", action: callback }]);
+
+    const actionSpan = el.querySelector('[data-chat="notice-actions"] span') as HTMLSpanElement;
+    actionSpan.click();
+
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it("calls the correct callback when multiple actions exist", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const third = vi.fn();
+    const el = renderNotice(tpl, "Delete messages?", [
+      { label: "all", action: first },
+      { label: "this one", action: second },
+      { label: "none", action: third },
+    ]);
+
+    const spans = el.querySelectorAll('[data-chat="notice-actions"] span');
+    (spans[1] as HTMLSpanElement).click();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+    expect(third).not.toHaveBeenCalled();
+  });
+
+  it("hides actions and updates text after clicking an action", () => {
+    const el = renderNotice(tpl, "Blocked user", [{ label: "unblock", action: () => {} }]);
+
+    const actionsEl = el.querySelector('[data-chat="notice-actions"]') as HTMLElement;
+    const textEl = el.querySelector('[data-chat="notice-text"]') as HTMLElement;
+    const actionSpan = actionsEl.querySelector("span") as HTMLSpanElement;
+
+    actionSpan.click();
+
+    expect(actionsEl.hidden).toBe(true);
+    expect(textEl.textContent).toBe("Blocked user — unblock");
+  });
+
+  it("adds separators between multiple actions", () => {
+    const el = renderNotice(tpl, "test", [
+      { label: "a", action: () => {} },
+      { label: "b", action: () => {} },
+    ]);
+    const actionsEl = el.querySelector('[data-chat="notice-actions"]') as HTMLElement;
+    expect(actionsEl.textContent).toContain(" · ");
+  });
+});

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -10,6 +10,9 @@ const RECONNECT_DELAY_MS = 3000;
 const CLIENT_MESSAGE_TYPE = {
   JOIN: "join",
   MESSAGE: "message",
+  DELETE: "delete",
+  FLAG: "flag",
+  DELETE_BY_USER: "delete_by_user",
 } as const;
 
 const SERVER_MESSAGE_TYPE = {
@@ -18,6 +21,8 @@ const SERVER_MESSAGE_TYPE = {
   BLOCKED: "blocked",
   UNBLOCKED: "unblocked",
   HELP: "help",
+  FLAGGED: "flagged",
+  BLOCKED_LIST: "blocked_list",
   JOINED: "joined",
   STATUS: "status",
   HISTORY: "history",
@@ -46,7 +51,9 @@ type ServerMessage =
   | { type: "warning"; code: string; message: string }
   | { type: "blocked"; code: string; message: string }
   | { type: "unblocked"; ip: string }
-  | { type: "help"; commands: Array<{ name: string; description: string }> };
+  | { type: "help"; commands: Array<{ name: string; description: string }> }
+  | { type: "flagged"; username: string; ip: string; messageId: string }
+  | { type: "blocked_list"; entries: Array<{ ip: string; username: string; blockedAt: number }> };
 
 interface ChatMessage {
   id: string;
@@ -109,6 +116,11 @@ function clearIdentity(): void {
 const msgTpl = document.getElementById("chat-msg-tpl") as HTMLTemplateElement;
 const noticeTpl = document.getElementById("chat-notice-tpl") as HTMLTemplateElement;
 
+function wsSend(data: Record<string, unknown>): void {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify(data));
+}
+
 function appendMessage(msg: ChatMessage): void {
   const isAdmin = adminUsername != null && msg.username === adminUsername;
   const frag = msgTpl.content.cloneNode(true) as DocumentFragment;
@@ -138,6 +150,34 @@ function appendMessage(msg: ChatMessage): void {
 
   slot("text").textContent = msg.text;
 
+  if (isOwner && !isAdmin) {
+    const controls = slot("admin-controls");
+    controls.hidden = false;
+
+    const deleteBtn = slot("delete-btn") as HTMLButtonElement;
+    const flagBtn = slot("flag-btn") as HTMLButtonElement;
+
+    deleteBtn.addEventListener("click", () => {
+      if (deleteBtn.dataset.confirm !== undefined) {
+        wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE, data: { id: msg.id } });
+        delete deleteBtn.dataset.confirm;
+      } else {
+        deleteBtn.dataset.confirm = "";
+        setTimeout(() => delete deleteBtn.dataset.confirm, 3000);
+      }
+    });
+
+    flagBtn.addEventListener("click", () => {
+      if (flagBtn.dataset.confirm !== undefined) {
+        wsSend({ type: CLIENT_MESSAGE_TYPE.FLAG, data: { id: msg.id } });
+        delete flagBtn.dataset.confirm;
+      } else {
+        flagBtn.dataset.confirm = "";
+        setTimeout(() => delete flagBtn.dataset.confirm, 3000);
+      }
+    });
+  }
+
   messagesEl.appendChild(frag);
   messagesEl.scrollTop = messagesEl.scrollHeight;
 }
@@ -148,6 +188,31 @@ function appendNotice(text: string): void {
   root.textContent = text;
   messagesEl.appendChild(frag);
   messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+function appendInteractiveNotice(text: string, actions: Array<{ label: string; action: () => void }>): HTMLElement {
+  const frag = noticeTpl.content.cloneNode(true) as DocumentFragment;
+  const root = frag.firstElementChild as HTMLElement;
+  root.textContent = "";
+
+  const textNode = document.createTextNode(text + "  ");
+  root.appendChild(textNode);
+
+  actions.forEach((a, i) => {
+    if (i > 0) root.appendChild(document.createTextNode(" · "));
+    const span = document.createElement("span");
+    span.textContent = `[${a.label}]`;
+    span.className = "cursor-pointer underline hover:text-teal not-italic";
+    span.addEventListener("click", () => {
+      a.action();
+      root.textContent = `${text} — ${a.label}`;
+    });
+    root.appendChild(span);
+  });
+
+  messagesEl.appendChild(frag);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+  return root;
 }
 
 function sendJoin(): void {
@@ -244,6 +309,25 @@ function connect(): void {
     } else if (data.type === SERVER_MESSAGE_TYPE.HELP) {
       const lines = data.commands.map((c) => `  /${c.name} — ${c.description}`);
       appendNotice(`Available commands:\n${lines.join("\n")}`);
+    } else if (data.type === SERVER_MESSAGE_TYPE.FLAGGED) {
+      appendInteractiveNotice(`Banned ${data.username} (${data.ip}).\nDelete their messages?`, [
+        {
+          label: "all",
+          action: () => wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE_BY_USER, data: { username: data.username } }),
+        },
+        { label: "this one", action: () => wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE, data: { id: data.messageId } }) },
+        { label: "none", action: () => {} },
+      ]);
+    } else if (data.type === SERVER_MESSAGE_TYPE.BLOCKED_LIST) {
+      if (data.entries.length === 0) {
+        appendNotice("No blocked users.");
+      } else {
+        const lines = data.entries.map((e) => {
+          const date = e.blockedAt > 0 ? new Date(e.blockedAt).toLocaleDateString() : "unknown date";
+          return `  ${e.username} — ${e.ip} (blocked ${date})`;
+        });
+        appendNotice(`Blocked users:\n${lines.join("\n")}`);
+      }
     }
   });
 

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -168,7 +168,8 @@ function appendMessage(msg: ChatMessage): void {
     const snippet = msg.text.length > 50 ? msg.text.slice(0, 50) + "…" : msg.text;
 
     deleteBtn.addEventListener("click", () => {
-      if (confirm(`Delete message from ${msg.username}?\n\n"${snippet}"`)) {
+      const currentName = usernameEl.textContent ?? msg.username;
+      if (confirm(`Delete message from ${currentName}?\n\n"${snippet}"`)) {
         wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE, data: { id: msg.id } });
       }
     });
@@ -179,7 +180,8 @@ function appendMessage(msg: ChatMessage): void {
     }
 
     flagBtn.addEventListener("click", () => {
-      if (confirm(`Flag & ban ${msg.username}?\n\n"${snippet}"`)) {
+      const currentName = usernameEl.textContent ?? msg.username;
+      if (confirm(`Flag & ban ${currentName}?\n\n"${snippet}"`)) {
         wsSend({ type: CLIENT_MESSAGE_TYPE.FLAG, data: { id: msg.id } });
       }
     });

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -1,15 +1,11 @@
-import {
-  generateRandomUsername,
-  validateUsername,
-  setAdminUsername,
-  LS_ADMIN_TOKEN_KEY,
-} from "@components/Chat/chat-utils";
+import { validateUsername, setAdminUsername, LS_ADMIN_TOKEN_KEY } from "@components/Chat/chat-utils";
 import { truncateMiddle, formatMessageTime, renderNotice } from "@components/Chat/chat-render";
 
 const RECONNECT_DELAY_MS = 3000;
 
 const CLIENT_MESSAGE_TYPE = {
   JOIN: "join",
+  RENAME: "rename",
   MESSAGE: "message",
   DELETE: "delete",
   FLAG: "flag",
@@ -71,13 +67,10 @@ interface ChatMessage {
   context?: MessageContext;
 }
 
-const MAX_AUTO_RETRIES = 5;
-
 const WS_URL =
   document.querySelector<HTMLMetaElement>('meta[name="chat-ws-url"]')?.content?.trim() || "ws://localhost:8787/ws";
 const API_BASE = WS_URL.replace(/^ws(s?):/, "http$1:").replace(/\/ws$/, "");
 
-const LS_USERNAME_KEY = "chat_username";
 const LS_CLIENT_ID_KEY = "chat_client_id";
 
 let ws: WebSocket | null = null;
@@ -85,7 +78,6 @@ let username: string | null = null;
 let clientId: string | null = null;
 let adminUsername: string | null = null;
 let isOwner = false;
-let autoRetries = 0;
 let pendingRename = false;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -109,18 +101,6 @@ function loadIdentity(): void {
     clientId = crypto.randomUUID();
     localStorage.setItem(LS_CLIENT_ID_KEY, clientId);
   }
-  username = localStorage.getItem(LS_USERNAME_KEY);
-}
-
-function saveUsername(name: string): void {
-  localStorage.setItem(LS_USERNAME_KEY, name);
-}
-
-function clearIdentity(): void {
-  localStorage.removeItem(LS_USERNAME_KEY);
-  localStorage.removeItem(LS_CLIENT_ID_KEY);
-  clientId = crypto.randomUUID();
-  localStorage.setItem(LS_CLIENT_ID_KEY, clientId);
 }
 
 const msgTpl = document.getElementById("chat-msg-tpl") as HTMLTemplateElement;
@@ -138,19 +118,20 @@ function wsSend(data: ClientModAction): void {
 }
 
 function appendMessage(msg: ChatMessage): void {
-  const isAdmin = adminUsername != null && msg.username === adminUsername;
+  const isAdminMsg = adminUsername != null && msg.username === adminUsername;
+  const showAsAdmin = (isOwner && msg.isOwn && !isAdminMsg) || (!isOwner && isAdminMsg);
   const frag = msgTpl.content.cloneNode(true) as DocumentFragment;
   const root = frag.firstElementChild as HTMLElement;
 
   root.dataset.msgId = String(msg.id);
   if (msg.clientId) root.dataset.clientId = msg.clientId;
-  if (msg.isOwn) root.dataset.own = "";
+  if (msg.isOwn && !showAsAdmin) root.dataset.own = "";
 
   const slot = (name: string) => root.querySelector(`[data-chat="${name}"]`) as HTMLElement;
 
   const usernameEl = slot("username");
   usernameEl.textContent = msg.username;
-  if (isAdmin) usernameEl.dataset.admin = "";
+  if (showAsAdmin) usernameEl.dataset.admin = "";
 
   slot("time").textContent = formatMessageTime(msg.timestamp);
 
@@ -179,7 +160,7 @@ function appendMessage(msg: ChatMessage): void {
     });
 
     const flagBtn = slot("flag-btn") as HTMLButtonElement;
-    if (!isAdmin) {
+    if (!isAdminMsg) {
       flagBtn.hidden = false;
     }
 
@@ -203,12 +184,12 @@ function appendSystemMessage(text: string, actions?: Array<{ label: string; acti
 }
 
 function sendJoin(): void {
-  if (!ws || ws.readyState !== WebSocket.OPEN || !username) return;
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
 
   const token = getAdminToken();
-  const data: Record<string, string> = { username };
-  if (token) data.token = token;
+  const data: Record<string, string> = {};
   if (clientId) data.clientId = clientId;
+  if (token) data.token = token;
   ws.send(JSON.stringify({ type: CLIENT_MESSAGE_TYPE.JOIN, data }));
 }
 
@@ -230,7 +211,6 @@ function connect(): void {
       isOwner = data.isOwner;
       username = data.username;
       usernameInput.value = data.username;
-      saveUsername(data.username);
       updateAdminUI();
       setBlocked(data.isBlocked);
     } else if (data.type === SERVER_MESSAGE_TYPE.HISTORY) {
@@ -251,35 +231,13 @@ function connect(): void {
     } else if (data.type === SERVER_MESSAGE_TYPE.STATUS) {
       updateStatus(data.isOwnerOnline, data.userCount);
     } else if (data.type === SERVER_MESSAGE_TYPE.ERROR) {
-      const usernameErrors = new Set(["invalid_username", "reserved_username", "taken_username", "expired_username"]);
-
-      if (data.code === "expired_username") {
-        clearIdentity();
-        username = generateRandomUsername();
-        usernameInput.value = username;
-        sendJoin();
-        return;
-      }
+      const usernameErrors = new Set(["invalid_username", "reserved_username", "taken_username"]);
 
       if (pendingRename && usernameErrors.has(data.code)) {
         pendingRename = false;
         usernameInput.setCustomValidity(data.message);
         usernameInput.reportValidity();
         usernameInput.value = username ?? "";
-        return;
-      }
-
-      if (usernameErrors.has(data.code) && autoRetries < MAX_AUTO_RETRIES) {
-        autoRetries++;
-        username = generateRandomUsername();
-        usernameInput.value = username;
-        sendJoin();
-        return;
-      }
-
-      if (usernameErrors.has(data.code)) {
-        appendSystemMessage("Could not auto-join. Please change your username and try saving.");
-        usernameInput.focus();
         return;
       }
 
@@ -376,6 +334,7 @@ function validateUsernameInput(): boolean {
 
 function changeUsername(): void {
   if (isOwner) return;
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
   if (!validateUsernameInput()) {
     usernameInput.reportValidity();
     return;
@@ -385,8 +344,7 @@ function changeUsername(): void {
   if (newName === username) return;
 
   pendingRename = true;
-  username = newName;
-  sendJoin();
+  ws.send(JSON.stringify({ type: CLIENT_MESSAGE_TYPE.RENAME, data: { username: newName } }));
 }
 
 usernameInput.addEventListener("input", () => validateUsernameInput());
@@ -461,9 +419,5 @@ async function fetchConfig(): Promise<void> {
 
 fetchConfig().then(() => {
   loadIdentity();
-  if (!username) {
-    username = generateRandomUsername();
-  }
-  usernameInput.value = username;
   connect();
 });

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -119,19 +119,20 @@ function wsSend(data: ClientModAction): void {
 
 function appendMessage(msg: ChatMessage): void {
   const isAdminMsg = adminUsername != null && msg.username === adminUsername;
-  const showAsAdmin = (isOwner && msg.isOwn && !isAdminMsg) || (!isOwner && isAdminMsg);
   const frag = msgTpl.content.cloneNode(true) as DocumentFragment;
   const root = frag.firstElementChild as HTMLElement;
 
   root.dataset.msgId = String(msg.id);
   if (msg.clientId) root.dataset.clientId = msg.clientId;
-  if (msg.isOwn && !showAsAdmin) root.dataset.own = "";
+  if (msg.isOwn) root.dataset.own = "";
 
   const slot = (name: string) => root.querySelector(`[data-chat="${name}"]`) as HTMLElement;
 
   const usernameEl = slot("username");
   usernameEl.textContent = msg.username;
-  if (showAsAdmin) usernameEl.dataset.admin = "";
+  const isCurrentUser = msg.isOwn && msg.username === username;
+  if (isCurrentUser) usernameEl.dataset.own = "";
+  else if (isAdminMsg) usernameEl.dataset.admin = "";
 
   slot("time").textContent = formatMessageTime(msg.timestamp);
 

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -116,7 +116,12 @@ function clearIdentity(): void {
 const msgTpl = document.getElementById("chat-msg-tpl") as HTMLTemplateElement;
 const noticeTpl = document.getElementById("chat-notice-tpl") as HTMLTemplateElement;
 
-function wsSend(data: Record<string, unknown>): void {
+type ClientModAction =
+  | { type: typeof CLIENT_MESSAGE_TYPE.DELETE; data: { id: string } }
+  | { type: typeof CLIENT_MESSAGE_TYPE.FLAG; data: { id: string } }
+  | { type: typeof CLIENT_MESSAGE_TYPE.DELETE_BY_USER; data: { username: string } };
+
+function wsSend(data: ClientModAction): void {
   if (!ws || ws.readyState !== WebSocket.OPEN) return;
   ws.send(JSON.stringify(data));
 }

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -404,8 +404,7 @@ function updateStatus(isOwnerOnline: boolean, userCount: number): void {
   statusDotEl.dataset.online = String(isOwnerOnline);
   ownerStatusEl.textContent = isOwnerOnline ? `${ownerLabel} online` : `${ownerLabel} offline`;
   ownerStatusEl.dataset.online = String(isOwnerOnline);
-  const viewerLabel = userCount === 1 ? "viewer" : "viewers";
-  const viewerText = `${userCount} ${viewerLabel}`;
+  const viewerText = `${userCount} online`;
   (userCountEl.querySelector('[data-chat="viewer-count"]') as HTMLElement).textContent = viewerText;
   userCountEl.title = viewerText;
 }

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -13,6 +13,7 @@ const CLIENT_MESSAGE_TYPE = {
   DELETE: "delete",
   FLAG: "flag",
   DELETE_BY_USER: "delete_by_user",
+  UNBLOCK: "unblock",
 } as const;
 
 const SERVER_MESSAGE_TYPE = {
@@ -44,7 +45,7 @@ type ServerMessage =
       timestamp: number;
       context?: MessageContext;
     }
-  | { type: "joined"; isOwner: boolean; username: string }
+  | { type: "joined"; isOwner: boolean; username: string; isBlocked: boolean }
   | { type: "status"; isOwnerOnline: boolean; userCount: number }
   | { type: "error"; code: string; message: string }
   | { type: "remove"; id: string }
@@ -82,6 +83,7 @@ let pendingRename = false;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 const usernameInput = document.getElementById("chat-username") as HTMLInputElement;
+const usernameRow = document.getElementById("js-chat-username-row") as HTMLDivElement;
 const messagesEl = document.getElementById("js-chat-messages") as HTMLDivElement;
 const inputEl = document.getElementById("js-chat-input") as HTMLInputElement;
 const sendBtn = document.getElementById("js-chat-send") as HTMLButtonElement;
@@ -119,7 +121,8 @@ const noticeTpl = document.getElementById("chat-notice-tpl") as HTMLTemplateElem
 type ClientModAction =
   | { type: typeof CLIENT_MESSAGE_TYPE.DELETE; data: { id: string } }
   | { type: typeof CLIENT_MESSAGE_TYPE.FLAG; data: { id: string } }
-  | { type: typeof CLIENT_MESSAGE_TYPE.DELETE_BY_USER; data: { username: string } };
+  | { type: typeof CLIENT_MESSAGE_TYPE.DELETE_BY_USER; data: { username: string } }
+  | { type: typeof CLIENT_MESSAGE_TYPE.UNBLOCK; data: { ip: string } };
 
 function wsSend(data: ClientModAction): void {
   if (!ws || ws.readyState !== WebSocket.OPEN) return;
@@ -155,30 +158,28 @@ function appendMessage(msg: ChatMessage): void {
 
   slot("text").textContent = msg.text;
 
-  if (isOwner && !isAdmin) {
+  if (isOwner) {
     const controls = slot("admin-controls");
     controls.hidden = false;
 
     const deleteBtn = slot("delete-btn") as HTMLButtonElement;
-    const flagBtn = slot("flag-btn") as HTMLButtonElement;
+
+    const snippet = msg.text.length > 50 ? msg.text.slice(0, 50) + "…" : msg.text;
 
     deleteBtn.addEventListener("click", () => {
-      if (deleteBtn.dataset.confirm !== undefined) {
+      if (confirm(`Delete message from ${msg.username}?\n\n"${snippet}"`)) {
         wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE, data: { id: msg.id } });
-        delete deleteBtn.dataset.confirm;
-      } else {
-        deleteBtn.dataset.confirm = "";
-        setTimeout(() => delete deleteBtn.dataset.confirm, 3000);
       }
     });
 
+    const flagBtn = slot("flag-btn") as HTMLButtonElement;
+    if (isAdmin) {
+      flagBtn.hidden = true;
+    }
+
     flagBtn.addEventListener("click", () => {
-      if (flagBtn.dataset.confirm !== undefined) {
+      if (confirm(`Flag & ban ${msg.username}?\n\n"${snippet}"`)) {
         wsSend({ type: CLIENT_MESSAGE_TYPE.FLAG, data: { id: msg.id } });
-        delete flagBtn.dataset.confirm;
-      } else {
-        flagBtn.dataset.confirm = "";
-        setTimeout(() => delete flagBtn.dataset.confirm, 3000);
       }
     });
   }
@@ -187,33 +188,33 @@ function appendMessage(msg: ChatMessage): void {
   messagesEl.scrollTop = messagesEl.scrollHeight;
 }
 
-function appendNotice(text: string): void {
+function appendSystemMessage(text: string, actions?: Array<{ label: string; action: () => void }>): HTMLElement {
   const frag = noticeTpl.content.cloneNode(true) as DocumentFragment;
   const root = frag.firstElementChild as HTMLElement;
-  root.textContent = text;
-  messagesEl.appendChild(frag);
-  messagesEl.scrollTop = messagesEl.scrollHeight;
-}
 
-function appendInteractiveNotice(text: string, actions: Array<{ label: string; action: () => void }>): HTMLElement {
-  const frag = noticeTpl.content.cloneNode(true) as DocumentFragment;
-  const root = frag.firstElementChild as HTMLElement;
-  root.textContent = "";
+  const timeEl = root.querySelector('[data-chat="notice-time"]') as HTMLElement;
+  timeEl.textContent = new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 
-  const textNode = document.createTextNode(text + "  ");
-  root.appendChild(textNode);
+  const textEl = root.querySelector('[data-chat="notice-text"]') as HTMLElement;
 
-  actions.forEach((a, i) => {
-    if (i > 0) root.appendChild(document.createTextNode(" · "));
-    const span = document.createElement("span");
-    span.textContent = `[${a.label}]`;
-    span.className = "cursor-pointer underline hover:text-teal not-italic";
-    span.addEventListener("click", () => {
-      a.action();
-      root.textContent = `${text} — ${a.label}`;
+  if (!actions || actions.length === 0) {
+    textEl.textContent = text;
+  } else {
+    const textNode = document.createTextNode(text + "  ");
+    textEl.appendChild(textNode);
+
+    actions.forEach((a, i) => {
+      if (i > 0) textEl.appendChild(document.createTextNode(" · "));
+      const span = document.createElement("span");
+      span.textContent = `[${a.label}]`;
+      span.className = "cursor-pointer underline text-text hover:text-teal";
+      span.addEventListener("click", () => {
+        a.action();
+        textEl.textContent = `${text} — ${a.label}`;
+      });
+      textEl.appendChild(span);
     });
-    root.appendChild(span);
-  });
+  }
 
   messagesEl.appendChild(frag);
   messagesEl.scrollTop = messagesEl.scrollHeight;
@@ -250,6 +251,7 @@ function connect(): void {
       usernameInput.value = data.username;
       saveUsername(data.username);
       updateAdminUI();
+      setBlocked(data.isBlocked);
     } else if (data.type === SERVER_MESSAGE_TYPE.HISTORY) {
       messagesEl.innerHTML = "";
       for (const msg of data.messages) {
@@ -264,15 +266,10 @@ function connect(): void {
         context: data.context,
       });
     } else if (data.type === SERVER_MESSAGE_TYPE.STATUS) {
-      const ownerLabel = adminUsername ?? "owner";
-      statusDotEl.dataset.online = String(data.isOwnerOnline);
-      ownerStatusEl.textContent = data.isOwnerOnline ? `${ownerLabel} online` : `${ownerLabel} offline`;
-      ownerStatusEl.dataset.online = String(data.isOwnerOnline);
-      const viewerLabel = data.userCount === 1 ? "viewer" : "viewers";
-      const viewerText = `${data.userCount} ${viewerLabel}`;
-      (userCountEl.querySelector('[data-chat="viewer-count"]') as HTMLElement).textContent = viewerText;
-      userCountEl.title = viewerText;
+      updateStatus(data.isOwnerOnline, data.userCount);
     } else if (data.type === SERVER_MESSAGE_TYPE.ERROR) {
+      const usernameErrors = new Set(["invalid_username", "reserved_username", "taken_username", "expired_username"]);
+
       if (data.code === "expired_username") {
         clearIdentity();
         username = generateRandomUsername();
@@ -281,7 +278,7 @@ function connect(): void {
         return;
       }
 
-      if (pendingRename) {
+      if (pendingRename && usernameErrors.has(data.code)) {
         pendingRename = false;
         usernameInput.setCustomValidity(data.message);
         usernameInput.reportValidity();
@@ -289,7 +286,7 @@ function connect(): void {
         return;
       }
 
-      if (autoRetries < MAX_AUTO_RETRIES) {
+      if (usernameErrors.has(data.code) && autoRetries < MAX_AUTO_RETRIES) {
         autoRetries++;
         username = generateRandomUsername();
         usernameInput.value = username;
@@ -297,25 +294,28 @@ function connect(): void {
         return;
       }
 
-      appendNotice("Could not auto-join. Please change your username and try saving.");
-      usernameInput.focus();
+      if (usernameErrors.has(data.code)) {
+        appendSystemMessage("Could not auto-join. Please change your username and try saving.");
+        usernameInput.focus();
+        return;
+      }
+
+      appendSystemMessage(data.message);
     } else if (data.type === SERVER_MESSAGE_TYPE.REMOVE) {
       const el = messagesEl.querySelector(`[data-msg-id="${data.id}"]`);
       if (el) el.remove();
     } else if (data.type === SERVER_MESSAGE_TYPE.WARNING) {
-      appendNotice(data.message);
+      appendSystemMessage(data.message);
     } else if (data.type === SERVER_MESSAGE_TYPE.BLOCKED) {
-      appendNotice(data.message);
-      inputEl.disabled = true;
-      sendBtn.disabled = true;
-      inputEl.placeholder = "You have been blocked.";
+      appendSystemMessage(data.message);
+      setBlocked(true);
     } else if (data.type === SERVER_MESSAGE_TYPE.UNBLOCKED) {
-      appendNotice(`Unblocked IP: ${data.ip}`);
+      appendSystemMessage(`Unblocked IP: ${data.ip}`);
     } else if (data.type === SERVER_MESSAGE_TYPE.HELP) {
       const lines = data.commands.map((c) => `  /${c.name} — ${c.description}`);
-      appendNotice(`Available commands:\n${lines.join("\n")}`);
+      appendSystemMessage(`Available commands:\n${lines.join("\n")}`);
     } else if (data.type === SERVER_MESSAGE_TYPE.FLAGGED) {
-      appendInteractiveNotice(`Banned ${data.username} (${data.ip}).\nDelete their messages?`, [
+      appendSystemMessage(`Banned ${data.username} (${data.ip}).\nDelete their messages?`, [
         {
           label: "all",
           action: () => wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE_BY_USER, data: { username: data.username } }),
@@ -325,13 +325,20 @@ function connect(): void {
       ]);
     } else if (data.type === SERVER_MESSAGE_TYPE.BLOCKED_LIST) {
       if (data.entries.length === 0) {
-        appendNotice("No blocked users.");
+        appendSystemMessage("No blocked users.");
       } else {
-        const lines = data.entries.map((e) => {
+        appendSystemMessage(`Blocked users (${data.entries.length}):`);
+        for (const e of data.entries) {
           const date = e.blockedAt > 0 ? new Date(e.blockedAt).toLocaleDateString() : "unknown date";
-          return `  ${e.username} — ${e.ip} (blocked ${date})`;
-        });
-        appendNotice(`Blocked users:\n${lines.join("\n")}`);
+          appendSystemMessage(`  ${e.username} — ${e.ip} (blocked ${date})`, [
+            {
+              label: "unblock",
+              action: () => {
+                wsSend({ type: CLIENT_MESSAGE_TYPE.UNBLOCK, data: { ip: e.ip } });
+              },
+            },
+          ]);
+        }
       }
     }
   });
@@ -406,6 +413,24 @@ usernameInput.addEventListener("keydown", (e) => {
 usernameInput.addEventListener("blur", () => {
   changeUsername();
 });
+
+function updateStatus(isOwnerOnline: boolean, userCount: number): void {
+  const ownerLabel = adminUsername ?? "owner";
+  statusDotEl.dataset.online = String(isOwnerOnline);
+  ownerStatusEl.textContent = isOwnerOnline ? `${ownerLabel} online` : `${ownerLabel} offline`;
+  ownerStatusEl.dataset.online = String(isOwnerOnline);
+  const viewerLabel = userCount === 1 ? "viewer" : "viewers";
+  const viewerText = `${userCount} ${viewerLabel}`;
+  (userCountEl.querySelector('[data-chat="viewer-count"]') as HTMLElement).textContent = viewerText;
+  userCountEl.title = viewerText;
+}
+
+function setBlocked(blocked: boolean): void {
+  usernameRow.hidden = blocked;
+  inputEl.disabled = blocked;
+  sendBtn.disabled = blocked;
+  inputEl.placeholder = blocked ? "You have been blocked." : "";
+}
 
 function updateAdminUI(): void {
   const adminLinks = document.querySelectorAll<HTMLAnchorElement>("#js-admin-link");

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -4,6 +4,7 @@ import {
   setAdminUsername,
   LS_ADMIN_TOKEN_KEY,
 } from "@components/Chat/chat-utils";
+import { truncateMiddle, formatMessageTime, renderNotice } from "@components/Chat/chat-render";
 
 const RECONNECT_DELAY_MS = 3000;
 
@@ -142,27 +143,22 @@ function appendMessage(msg: ChatMessage): void {
   usernameEl.textContent = msg.username;
   if (isAdmin) usernameEl.dataset.admin = "";
 
-  const time = new Date(msg.timestamp).toLocaleTimeString([], {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-  slot("time").textContent = time;
+  slot("time").textContent = formatMessageTime(msg.timestamp);
 
   if (msg.context) {
     const pageLink = slot("page") as HTMLAnchorElement;
     pageLink.href = msg.context.path;
-    pageLink.textContent = msg.context.path;
+    pageLink.textContent = truncateMiddle(msg.context.path, 25);
+    pageLink.title = msg.context.path;
     pageLink.hidden = false;
-    slot("sep").hidden = false;
+    slot("at-sep").hidden = false;
   }
 
   slot("text").textContent = msg.text;
 
   if (isOwner) {
-    const controls = slot("admin-controls");
-    controls.hidden = false;
-
     const deleteBtn = slot("delete-btn") as HTMLButtonElement;
+    deleteBtn.hidden = false;
 
     const snippet = msg.text.length > 50 ? msg.text.slice(0, 50) + "…" : msg.text;
 
@@ -173,8 +169,8 @@ function appendMessage(msg: ChatMessage): void {
     });
 
     const flagBtn = slot("flag-btn") as HTMLButtonElement;
-    if (isAdmin) {
-      flagBtn.hidden = true;
+    if (!isAdmin) {
+      flagBtn.hidden = false;
     }
 
     flagBtn.addEventListener("click", () => {
@@ -189,34 +185,8 @@ function appendMessage(msg: ChatMessage): void {
 }
 
 function appendSystemMessage(text: string, actions?: Array<{ label: string; action: () => void }>): HTMLElement {
-  const frag = noticeTpl.content.cloneNode(true) as DocumentFragment;
-  const root = frag.firstElementChild as HTMLElement;
-
-  const timeEl = root.querySelector('[data-chat="notice-time"]') as HTMLElement;
-  timeEl.textContent = new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
-
-  const textEl = root.querySelector('[data-chat="notice-text"]') as HTMLElement;
-
-  textEl.textContent = text;
-
-  if (actions && actions.length > 0) {
-    const actionsEl = root.querySelector('[data-chat="notice-actions"]') as HTMLElement;
-    actionsEl.hidden = false;
-
-    actions.forEach((a, i) => {
-      if (i > 0) actionsEl.appendChild(document.createTextNode(" · "));
-      const span = document.createElement("span");
-      span.textContent = `[${a.label}]`;
-      span.className = "cursor-pointer text-text hover:text-teal";
-      span.addEventListener("click", () => {
-        actionsEl.hidden = true;
-        textEl.textContent = `${text} — ${a.label}`;
-      });
-      actionsEl.appendChild(span);
-    });
-  }
-
-  messagesEl.appendChild(frag);
+  const root = renderNotice(noticeTpl, text, actions);
+  messagesEl.appendChild(root);
   messagesEl.scrollTop = messagesEl.scrollHeight;
   return root;
 }

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -17,6 +17,7 @@ const SERVER_MESSAGE_TYPE = {
   WARNING: "warning",
   BLOCKED: "blocked",
   UNBLOCKED: "unblocked",
+  HELP: "help",
   JOINED: "joined",
   STATUS: "status",
   HISTORY: "history",
@@ -44,7 +45,8 @@ type ServerMessage =
   | { type: "remove"; id: string }
   | { type: "warning"; code: string; message: string }
   | { type: "blocked"; code: string; message: string }
-  | { type: "unblocked"; ip: string };
+  | { type: "unblocked"; ip: string }
+  | { type: "help"; commands: Array<{ name: string; description: string }> };
 
 interface ChatMessage {
   id: string;
@@ -239,6 +241,9 @@ function connect(): void {
       inputEl.placeholder = "You have been blocked.";
     } else if (data.type === SERVER_MESSAGE_TYPE.UNBLOCKED) {
       appendNotice(`Unblocked IP: ${data.ip}`);
+    } else if (data.type === SERVER_MESSAGE_TYPE.HELP) {
+      const lines = data.commands.map((c) => `  /${c.name} — ${c.description}`);
+      appendNotice(`Available commands:\n${lines.join("\n")}`);
     }
   });
 

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -30,6 +30,7 @@ const SERVER_MESSAGE_TYPE = {
   HISTORY: "history",
   REMOVE: "remove",
   MESSAGE: "message",
+  RENAME: "rename",
 } as const;
 
 interface MessageContext {
@@ -41,6 +42,7 @@ type ServerMessage =
   | {
       type: "message";
       id: string;
+      clientId: string;
       username: string;
       text: string;
       timestamp: number;
@@ -52,13 +54,15 @@ type ServerMessage =
   | { type: "remove"; id: string }
   | { type: "warning"; code: string; message: string }
   | { type: "blocked"; code: string; message: string }
-  | { type: "unblocked"; ip: string }
+  | { type: "unblocked"; clientId: string }
   | { type: "help"; commands: Array<{ name: string; description: string }> }
-  | { type: "flagged"; username: string; ip: string; messageId: string }
-  | { type: "blocked_list"; entries: Array<{ ip: string; username: string; blockedAt: number }> };
+  | { type: "flagged"; username: string; clientId: string; messageId: string }
+  | { type: "blocked_list"; entries: Array<{ clientId: string; username: string; blockedAt: number }> }
+  | { type: "rename"; oldUsername: string; newUsername: string };
 
 interface ChatMessage {
   id: string;
+  clientId: string;
   username: string;
   text: string;
   timestamp: number;
@@ -122,8 +126,8 @@ const noticeTpl = document.getElementById("chat-notice-tpl") as HTMLTemplateElem
 type ClientModAction =
   | { type: typeof CLIENT_MESSAGE_TYPE.DELETE; data: { id: string } }
   | { type: typeof CLIENT_MESSAGE_TYPE.FLAG; data: { id: string } }
-  | { type: typeof CLIENT_MESSAGE_TYPE.DELETE_BY_USER; data: { username: string } }
-  | { type: typeof CLIENT_MESSAGE_TYPE.UNBLOCK; data: { ip: string } };
+  | { type: typeof CLIENT_MESSAGE_TYPE.DELETE_BY_USER; data: { clientId: string } }
+  | { type: typeof CLIENT_MESSAGE_TYPE.UNBLOCK; data: { clientId: string } };
 
 function wsSend(data: ClientModAction): void {
   if (!ws || ws.readyState !== WebSocket.OPEN) return;
@@ -136,6 +140,7 @@ function appendMessage(msg: ChatMessage): void {
   const root = frag.firstElementChild as HTMLElement;
 
   root.dataset.msgId = String(msg.id);
+  root.dataset.clientId = msg.clientId;
 
   const slot = (name: string) => root.querySelector(`[data-chat="${name}"]`) as HTMLElement;
 
@@ -230,6 +235,7 @@ function connect(): void {
     } else if (data.type === SERVER_MESSAGE_TYPE.MESSAGE) {
       appendMessage({
         id: data.id,
+        clientId: data.clientId,
         username: data.username,
         text: data.text,
         timestamp: data.timestamp,
@@ -274,21 +280,28 @@ function connect(): void {
     } else if (data.type === SERVER_MESSAGE_TYPE.REMOVE) {
       const el = messagesEl.querySelector(`[data-msg-id="${data.id}"]`);
       if (el) el.remove();
+    } else if (data.type === SERVER_MESSAGE_TYPE.RENAME) {
+      const usernameEls = messagesEl.querySelectorAll<HTMLElement>('[data-chat="username"]');
+      for (const el of usernameEls) {
+        if (el.textContent === data.oldUsername) {
+          el.textContent = data.newUsername;
+        }
+      }
     } else if (data.type === SERVER_MESSAGE_TYPE.WARNING) {
       appendSystemMessage(data.message);
     } else if (data.type === SERVER_MESSAGE_TYPE.BLOCKED) {
       appendSystemMessage(data.message);
       setBlocked(true);
     } else if (data.type === SERVER_MESSAGE_TYPE.UNBLOCKED) {
-      appendSystemMessage(`Unblocked IP: ${data.ip}`);
+      appendSystemMessage(`Unblocked user: ${data.clientId.slice(0, 8)}\u2026`);
     } else if (data.type === SERVER_MESSAGE_TYPE.HELP) {
       const lines = data.commands.map((c) => `  /${c.name} — ${c.description}`);
       appendSystemMessage(`Available commands:\n${lines.join("\n")}`);
     } else if (data.type === SERVER_MESSAGE_TYPE.FLAGGED) {
-      appendSystemMessage(`Banned ${data.username} (${data.ip}).\nDelete their messages?`, [
+      appendSystemMessage(`Banned ${data.username}.\nDelete their messages?`, [
         {
           label: "all",
-          action: () => wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE_BY_USER, data: { username: data.username } }),
+          action: () => wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE_BY_USER, data: { clientId: data.clientId } }),
         },
         { label: "this one", action: () => wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE, data: { id: data.messageId } }) },
         { label: "none", action: () => {} },
@@ -300,11 +313,11 @@ function connect(): void {
         appendSystemMessage(`Blocked users (${data.entries.length}):`);
         for (const e of data.entries) {
           const date = e.blockedAt > 0 ? new Date(e.blockedAt).toLocaleDateString() : "unknown date";
-          appendSystemMessage(`  ${e.username} — ${e.ip} (blocked ${date})`, [
+          appendSystemMessage(`  ${e.username} \u2014 ${e.clientId.slice(0, 8)}\u2026 (blocked ${date})`, [
             {
               label: "unblock",
               action: () => {
-                wsSend({ type: CLIENT_MESSAGE_TYPE.UNBLOCK, data: { ip: e.ip } });
+                wsSend({ type: CLIENT_MESSAGE_TYPE.UNBLOCK, data: { clientId: e.clientId } });
               },
             },
           ]);

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -94,6 +94,7 @@ const inputEl = document.getElementById("js-chat-input") as HTMLInputElement;
 const sendBtn = document.getElementById("js-chat-send") as HTMLButtonElement;
 const statusDotEl = document.getElementById("js-chat-status-dot") as HTMLSpanElement;
 const ownerStatusEl = document.getElementById("js-chat-owner-status") as HTMLSpanElement;
+const ownerWrapEl = document.getElementById("js-chat-owner-wrap") as HTMLSpanElement;
 const userCountEl = document.getElementById("js-chat-user-count") as HTMLSpanElement;
 
 function getAdminToken(): string | null {
@@ -402,11 +403,11 @@ usernameInput.addEventListener("blur", () => {
 function updateStatus(isOwnerOnline: boolean, userCount: number): void {
   const ownerLabel = adminUsername ?? "owner";
   statusDotEl.dataset.online = String(isOwnerOnline);
-  ownerStatusEl.textContent = isOwnerOnline ? `${ownerLabel} online` : `${ownerLabel} offline`;
+  ownerStatusEl.textContent = ownerLabel;
   ownerStatusEl.dataset.online = String(isOwnerOnline);
-  const viewerText = `${userCount} online`;
-  (userCountEl.querySelector('[data-chat="viewer-count"]') as HTMLElement).textContent = viewerText;
-  userCountEl.title = viewerText;
+  ownerWrapEl.title = `Site owner: ${isOwnerOnline ? "online" : "offline"}`;
+  (userCountEl.querySelector('[data-chat="viewer-count"]') as HTMLElement).textContent = String(userCount);
+  userCountEl.title = `${userCount} online`;
 }
 
 function setBlocked(blocked: boolean): void {
@@ -447,7 +448,7 @@ async function fetchConfig(): Promise<void> {
     if (data.adminUsername) {
       adminUsername = data.adminUsername;
       setAdminUsername(adminUsername);
-      ownerStatusEl.textContent = `${adminUsername} offline`;
+      ownerStatusEl.textContent = adminUsername;
     }
   } catch {
     console.warn("[chat] failed to fetch config, reserved name validation will be skipped client-side");

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -197,22 +197,22 @@ function appendSystemMessage(text: string, actions?: Array<{ label: string; acti
 
   const textEl = root.querySelector('[data-chat="notice-text"]') as HTMLElement;
 
-  if (!actions || actions.length === 0) {
-    textEl.textContent = text;
-  } else {
-    const textNode = document.createTextNode(text + "  ");
-    textEl.appendChild(textNode);
+  textEl.textContent = text;
+
+  if (actions && actions.length > 0) {
+    const actionsEl = root.querySelector('[data-chat="notice-actions"]') as HTMLElement;
+    actionsEl.hidden = false;
 
     actions.forEach((a, i) => {
-      if (i > 0) textEl.appendChild(document.createTextNode(" · "));
+      if (i > 0) actionsEl.appendChild(document.createTextNode(" · "));
       const span = document.createElement("span");
       span.textContent = `[${a.label}]`;
-      span.className = "cursor-pointer underline text-text hover:text-teal";
+      span.className = "cursor-pointer text-text hover:text-teal";
       span.addEventListener("click", () => {
-        a.action();
+        actionsEl.hidden = true;
         textEl.textContent = `${text} — ${a.label}`;
       });
-      textEl.appendChild(span);
+      actionsEl.appendChild(span);
     });
   }
 

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -42,7 +42,8 @@ type ServerMessage =
   | {
       type: "message";
       id: string;
-      clientId: string;
+      clientId?: string;
+      isOwn?: boolean;
       username: string;
       text: string;
       timestamp: number;
@@ -62,7 +63,8 @@ type ServerMessage =
 
 interface ChatMessage {
   id: string;
-  clientId: string;
+  clientId?: string;
+  isOwn?: boolean;
   username: string;
   text: string;
   timestamp: number;
@@ -141,7 +143,8 @@ function appendMessage(msg: ChatMessage): void {
   const root = frag.firstElementChild as HTMLElement;
 
   root.dataset.msgId = String(msg.id);
-  root.dataset.clientId = msg.clientId;
+  if (msg.clientId) root.dataset.clientId = msg.clientId;
+  if (msg.isOwn) root.dataset.own = "";
 
   const slot = (name: string) => root.querySelector(`[data-chat="${name}"]`) as HTMLElement;
 
@@ -239,6 +242,7 @@ function connect(): void {
       appendMessage({
         id: data.id,
         clientId: data.clientId,
+        isOwn: data.isOwn,
         username: data.username,
         text: data.text,
         timestamp: data.timestamp,

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -46,7 +46,7 @@ type ServerMessage =
       context?: MessageContext;
     }
   | { type: "joined"; isOwner: boolean; username: string; isBlocked: boolean }
-  | { type: "status"; isOwnerOnline: boolean; userCount: number }
+  | { type: "status"; isOwnerOnline: boolean; userCount: number; onlineUsernames: string[] }
   | { type: "error"; code: string; message: string }
   | { type: "remove"; id: string }
   | { type: "warning"; code: string; message: string }
@@ -230,7 +230,7 @@ function connect(): void {
         context: data.context,
       });
     } else if (data.type === SERVER_MESSAGE_TYPE.STATUS) {
-      updateStatus(data.isOwnerOnline, data.userCount);
+      updateStatus(data.isOwnerOnline, data.userCount, data.onlineUsernames);
     } else if (data.type === SERVER_MESSAGE_TYPE.ERROR) {
       const usernameErrors = new Set(["invalid_username", "reserved_username", "taken_username"]);
 
@@ -363,14 +363,26 @@ usernameInput.addEventListener("blur", () => {
   changeUsername();
 });
 
-function updateStatus(isOwnerOnline: boolean, userCount: number): void {
+function updateStatus(isOwnerOnline: boolean, userCount: number, onlineUsernames: string[]): void {
   const ownerLabel = adminUsername ?? "owner";
-  statusDotEl.dataset.online = String(isOwnerOnline);
+  if (isOwnerOnline) statusDotEl.dataset.online = "";
+  else delete statusDotEl.dataset.online;
   ownerStatusEl.textContent = ownerLabel;
-  ownerStatusEl.dataset.online = String(isOwnerOnline);
   ownerWrapEl.title = `Site owner: ${isOwnerOnline ? "online" : "offline"}`;
   (userCountEl.querySelector('[data-chat="viewer-count"]') as HTMLElement).textContent = String(userCount);
   userCountEl.title = `${userCount} online`;
+
+  const onlineSet = new Set(onlineUsernames);
+  for (const row of messagesEl.querySelectorAll<HTMLElement>("[data-msg-id]")) {
+    const dot = row.querySelector<HTMLElement>('[data-chat="status-dot"]');
+    const usernameEl = row.querySelector<HTMLElement>('[data-chat="username"]');
+    if (!dot || !usernameEl) continue;
+    if (onlineSet.has(usernameEl.textContent ?? "")) {
+      dot.dataset.online = "";
+    } else {
+      delete dot.dataset.online;
+    }
+  }
 }
 
 function setBlocked(blocked: boolean): void {

--- a/app/src/components/Chat/chat-render.ts
+++ b/app/src/components/Chat/chat-render.ts
@@ -29,16 +29,12 @@ export function truncateMiddle(path: string, maxLen: number): string {
 
 export function formatMessageTime(timestamp: number): string {
   const msgDate = new Date(timestamp);
-  const now = new Date();
-  const isToday =
-    msgDate.getFullYear() === now.getFullYear() &&
-    msgDate.getMonth() === now.getMonth() &&
-    msgDate.getDate() === now.getDate();
-  return isToday
-    ? msgDate.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
+  const isRecent = Date.now() - timestamp < 24 * 60 * 60 * 1000;
+  return isRecent
+    ? msgDate.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false })
     : msgDate.toLocaleDateString([], { month: "short", day: "numeric" }) +
         ", " +
-        msgDate.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+        msgDate.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
 }
 
 export function renderNotice(template: HTMLTemplateElement, text: string, actions?: NoticeAction[]): HTMLElement {
@@ -46,7 +42,7 @@ export function renderNotice(template: HTMLTemplateElement, text: string, action
   const root = frag.firstElementChild as HTMLElement;
 
   const timeEl = root.querySelector('[data-chat="notice-time"]') as HTMLElement;
-  timeEl.textContent = new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  timeEl.textContent = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
 
   const textEl = root.querySelector('[data-chat="notice-text"]') as HTMLElement;
   textEl.textContent = text;

--- a/app/src/components/Chat/chat-render.ts
+++ b/app/src/components/Chat/chat-render.ts
@@ -1,0 +1,73 @@
+export interface NoticeAction {
+  label: string;
+  action: () => void;
+}
+
+export function truncateMiddle(path: string, maxLen: number): string {
+  if (path.length <= maxLen) return path;
+  const sep = "/\u2026/";
+  const budget = maxLen - sep.length;
+  const headLen = Math.ceil(budget / 2);
+  const tailLen = Math.floor(budget / 2);
+  const parts = path.split("/").filter(Boolean);
+  let head = "";
+  let tail = "";
+  for (const p of parts) {
+    const next = head ? `${head}/${p}` : `/${p}`;
+    if (next.length > headLen) break;
+    head = next;
+  }
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const next = tail ? `${parts[i]}/${tail}` : parts[i];
+    if (next.length > tailLen) break;
+    tail = next;
+  }
+  if (!head) head = path.slice(0, headLen);
+  if (!tail) tail = path.slice(-tailLen);
+  return `${head}${sep}${tail}`;
+}
+
+export function formatMessageTime(timestamp: number): string {
+  const msgDate = new Date(timestamp);
+  const now = new Date();
+  const isToday =
+    msgDate.getFullYear() === now.getFullYear() &&
+    msgDate.getMonth() === now.getMonth() &&
+    msgDate.getDate() === now.getDate();
+  return isToday
+    ? msgDate.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
+    : msgDate.toLocaleDateString([], { month: "short", day: "numeric" }) +
+        ", " +
+        msgDate.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
+export function renderNotice(template: HTMLTemplateElement, text: string, actions?: NoticeAction[]): HTMLElement {
+  const frag = template.content.cloneNode(true) as DocumentFragment;
+  const root = frag.firstElementChild as HTMLElement;
+
+  const timeEl = root.querySelector('[data-chat="notice-time"]') as HTMLElement;
+  timeEl.textContent = new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+
+  const textEl = root.querySelector('[data-chat="notice-text"]') as HTMLElement;
+  textEl.textContent = text;
+
+  if (actions && actions.length > 0) {
+    const actionsEl = root.querySelector('[data-chat="notice-actions"]') as HTMLElement;
+    actionsEl.hidden = false;
+
+    actions.forEach((a, i) => {
+      if (i > 0) actionsEl.appendChild(document.createTextNode(" · "));
+      const span = document.createElement("span");
+      span.textContent = `[${a.label}]`;
+      span.className = "cursor-pointer text-text hover:text-teal";
+      span.addEventListener("click", () => {
+        a.action();
+        actionsEl.hidden = true;
+        textEl.textContent = `${text} — ${a.label}`;
+      });
+      actionsEl.appendChild(span);
+    });
+  }
+
+  return root;
+}

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -11,8 +11,8 @@
   --color-muted: #7a9ab5;
   --color-border: #152535;
   --color-surface-active: #0a1826;
-  --color-accent: #d4a520;
-  --color-admin: #a78bfa;
+  --color-accent: #7dd3fc;
+  --color-admin: #d4a520;
 
   --font-display: "Bricolage Grotesque", sans-serif;
   --font-heading: "Space Grotesk", sans-serif;

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -11,6 +11,7 @@
   --color-muted: #7a9ab5;
   --color-border: #152535;
   --color-surface-active: #0a1826;
+  --color-accent: #d4a520;
 
   --font-display: "Bricolage Grotesque", sans-serif;
   --font-heading: "Space Grotesk", sans-serif;

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -8,7 +8,7 @@
   --color-neon: #39ff14;
   --color-teal: #00e5a0;
   --color-text: #e8f0f8;
-  --color-muted: #7a9ab5;
+  --color-muted: #85a3bc;
   --color-border: #152535;
   --color-surface-active: #0a1826;
   --color-accent: #7dd3fc;

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -12,6 +12,7 @@
   --color-border: #152535;
   --color-surface-active: #0a1826;
   --color-accent: #d4a520;
+  --color-admin: #a78bfa;
 
   --font-display: "Bricolage Grotesque", sans-serif;
   --font-heading: "Space Grotesk", sans-serif;

--- a/docs/plans/2026-02-28-admin-help-command-design.md
+++ b/docs/plans/2026-02-28-admin-help-command-design.md
@@ -1,0 +1,70 @@
+# Admin /help Command — Design
+
+## Goal
+
+Add an admin-only `/help` slash command to the chat that shows available commands as a system notice. Build a command registry so `/help` auto-generates from registered commands.
+
+## Key Decisions
+
+- **Admin-only dispatch**: Only `isOwner` connections trigger command handling. Non-admin users typing `/help` or any `/command` have their message sent as regular chat text — no error, no hint that commands exist.
+- **Server-side registry**: Commands are registered in a central registry. `/help` iterates the registry to build its output.
+- **System notice display**: The help output renders as a styled system notice in the chat, visible only to the admin (not broadcast).
+- **New `HELP` server message type**: Carries an array of `{ name, description }` so the client can render it cleanly.
+
+## Architecture
+
+### Command Registry (`api/src/commands.ts`)
+
+```ts
+interface Command {
+  name: string;
+  description: string;
+  handler: (ws: WebSocket, args: string, chatRoom: ChatRoom) => void;
+}
+```
+
+- Exports a `commands` array and a `dispatch(text, ws, chatRoom)` function.
+- `dispatch` is only called when `isOwner` is true.
+- Built-in commands: `/help`, `/unblock <ip>`.
+
+### Dispatch Flow
+
+In `handleChatMessage`:
+
+1. If `info.isOwner` and text starts with `/` → call `dispatch(text, ws, chatRoom)`
+2. If dispatch returns `true` (command matched) → return early
+3. Otherwise → treat as normal message
+
+### Server Message Type
+
+New `HELP` type added to `SERVER_MESSAGE_TYPE` and `ServerMessage` union:
+
+```ts
+interface ServerHelpMessage {
+  type: "help";
+  commands: Array<{ name: string; description: string }>;
+}
+```
+
+### Client Handling
+
+In `chat-client.ts`, handle `help` message type by calling `appendNotice()` with formatted command list.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `api/src/commands.ts` | New — command registry with `/help` and `/unblock` |
+| `api/src/chat-room.ts` | Replace hardcoded `/unblock` regex with registry dispatch |
+| `api/src/types.ts` | Add `HELP` message type + `ServerHelpMessage` |
+| `app/src/components/Chat/chat-client.ts` | Handle `help` messages, render as notice |
+
+## Example Output
+
+When admin types `/help`:
+
+```
+Available commands:
+  /help — Show this help message
+  /unblock <ip> — Unblock a user by IP address
+```

--- a/docs/plans/2026-02-28-admin-help-command.md
+++ b/docs/plans/2026-02-28-admin-help-command.md
@@ -1,0 +1,420 @@
+# Admin /help Command Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an admin-only `/help` command and a command registry that auto-generates the help output.
+
+**Architecture:** Server-side command registry in `api/src/commands.ts`. Only `isOwner` connections trigger command dispatch — non-admin `/` messages pass through as regular chat text. A new `HELP` server message type carries command metadata to the client, rendered as a system notice.
+
+**Tech Stack:** TypeScript, Cloudflare Workers/Durable Objects, Vitest
+
+---
+
+### Task 1: Add types for the command registry and HELP message
+
+**Files:**
+- Modify: `api/src/types.ts`
+
+**Step 1: Add `HELP` to `SERVER_MESSAGE_TYPE`**
+
+In `api/src/types.ts`, add `HELP: "help"` to the `SERVER_MESSAGE_TYPE` object (after `UNBLOCKED`):
+
+```ts
+export const SERVER_MESSAGE_TYPE = {
+  ERROR: "error",
+  WARNING: "warning",
+  BLOCKED: "blocked",
+  UNBLOCKED: "unblocked",
+  HELP: "help",
+  JOINED: "joined",
+  STATUS: "status",
+  HISTORY: "history",
+  REMOVE: "remove",
+  MESSAGE: "message",
+} as const;
+```
+
+**Step 2: Add `ServerHelpMessage` interface**
+
+After the `ServerUnblockedMessage` interface, add:
+
+```ts
+export interface ServerHelpMessage {
+  type: "help";
+  commands: Array<{ name: string; description: string }>;
+}
+```
+
+**Step 3: Add `ServerHelpMessage` to the `ServerMessage` union**
+
+```ts
+export type ServerMessage =
+  | ServerErrorResponse
+  | ServerBroadcast
+  | ServerJoinedMessage
+  | ServerUnblockedMessage
+  | ServerHelpMessage
+  | ChatMessage;
+```
+
+**Step 4: Commit**
+
+```bash
+git add api/src/types.ts
+git commit -m "feat(api): add HELP server message type for command registry"
+```
+
+---
+
+### Task 2: Create the command registry
+
+**Files:**
+- Create: `api/src/commands.ts`
+
+**Step 1: Write the command registry**
+
+Create `api/src/commands.ts`:
+
+```ts
+import type { ChatRoom } from "./chat-room";
+import { SERVER_MESSAGE_TYPE } from "./types";
+
+interface Command {
+  name: string;
+  description: string;
+  handler: (ws: WebSocket, args: string, chatRoom: ChatRoom) => void;
+}
+
+const commands: Command[] = [];
+
+function register(command: Command): void {
+  commands.push(command);
+}
+
+register({
+  name: "help",
+  description: "Show this help message",
+  handler: (ws, _args, chatRoom) => {
+    chatRoom.sendToSocket(ws, {
+      type: SERVER_MESSAGE_TYPE.HELP,
+      commands: commands.map(({ name, description }) => ({ name, description })),
+    });
+  },
+});
+
+register({
+  name: "unblock",
+  description: "Unblock a user by IP address — /unblock <ip>",
+  handler: (ws, args, chatRoom) => {
+    chatRoom.handleUnblockCommand(ws, args);
+  },
+});
+
+export function dispatch(text: string, ws: WebSocket, chatRoom: ChatRoom): boolean {
+  const match = text.match(/^\/(\S+)\s*(.*)$/);
+  if (!match) return false;
+
+  const [, name, args] = match;
+  const command = commands.find((c) => c.name === name);
+  if (!command) return false;
+
+  command.handler(ws, args.trim(), chatRoom);
+  return true;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add api/src/commands.ts
+git commit -m "feat(api): add command registry with /help and /unblock"
+```
+
+---
+
+### Task 3: Refactor ChatRoom to use the command registry
+
+**Files:**
+- Modify: `api/src/chat-room.ts`
+
+**Step 1: Add public methods for command access**
+
+The command registry needs to call `send()` and `handleUnblock()` on `ChatRoom`. Add two public methods and import `dispatch`:
+
+At the top, add import:
+```ts
+import { dispatch } from "./commands";
+```
+
+Add two public methods to the `ChatRoom` class (before the `// ── Connection Helpers` section):
+
+```ts
+  // ── Command Interface ──────────────────────────────────────────────
+
+  sendToSocket(ws: WebSocket, message: ServerMessage): void {
+    this.send(ws, message);
+  }
+
+  handleUnblockCommand(ws: WebSocket, ip: string): void {
+    this.handleUnblock(ws, ip);
+  }
+```
+
+**Step 2: Replace hardcoded `/unblock` dispatch with registry**
+
+In `handleChatMessage`, replace the `/unblock` regex block:
+
+```ts
+    const unblockMatch = text.match(/^\/unblock\s+(.+)$/);
+    if (unblockMatch) {
+      this.handleUnblock(ws, unblockMatch[1].trim());
+      return;
+    }
+```
+
+With registry dispatch (only for owner):
+
+```ts
+    if (info.isOwner && text.startsWith("/")) {
+      if (dispatch(text, ws, this)) return;
+    }
+```
+
+**Step 3: Commit**
+
+```bash
+git add api/src/chat-room.ts
+git commit -m "feat(api): wire command registry into ChatRoom dispatch"
+```
+
+---
+
+### Task 4: Write tests for the command registry
+
+**Files:**
+- Modify: `api/src/__tests__/chat-room.test.ts`
+
+**Step 1: Add `/help` test — admin receives help with command list**
+
+Add to the "IP blocking" describe block (or create a new "admin commands" describe block after it):
+
+```ts
+  describe("admin commands", () => {
+    it("admin /help returns help message with command list", async () => {
+      const { ws, msgs } = await connectAndJoin("thalida", { token: "test-admin-secret" });
+      msgs.length = 0;
+
+      send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/help" } });
+      await flush();
+
+      const help = msgs.find((m) => m.type === SERVER_MESSAGE_TYPE.HELP);
+      expect(help).toBeDefined();
+      if (help && help.type === SERVER_MESSAGE_TYPE.HELP) {
+        expect(help.commands.length).toBeGreaterThanOrEqual(2);
+        const names = help.commands.map((c) => c.name);
+        expect(names).toContain("help");
+        expect(names).toContain("unblock");
+      }
+
+      ws.close();
+    });
+
+    it("/help is not broadcast to other users", async () => {
+      const { ws: adminWs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+        ip: "10.0.0.1",
+      });
+      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("viewer", { ip: "10.0.0.2" });
+      otherMsgs.length = 0;
+
+      send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/help" } });
+      await flush();
+
+      const anyMsg = otherMsgs.filter(
+        (m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE || m.type === SERVER_MESSAGE_TYPE.HELP,
+      );
+      expect(anyMsg).toHaveLength(0);
+
+      adminWs.close();
+      otherWs.close();
+    });
+
+    it("non-admin /help sends as regular chat message", async () => {
+      const { ws: ws1, msgs: msgs1 } = await connectAndJoin("regular");
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("observer");
+
+      msgs1.length = 0;
+      msgs2.length = 0;
+
+      send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/help" } });
+      await flush();
+
+      const msg = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      expect(msg).toMatchObject({ type: SERVER_MESSAGE_TYPE.MESSAGE, username: "regular", text: "/help" });
+
+      ws1.close();
+      ws2.close();
+    });
+
+    it("non-admin /unblock sends as regular chat message", async () => {
+      const { ws, msgs } = await connectAndJoin("regular-user", { ip: "10.0.0.2" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("watcher", { ip: "10.0.0.3" });
+
+      msgs.length = 0;
+      msgs2.length = 0;
+
+      send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/unblock 10.0.0.50" } });
+      await flush();
+
+      const msg = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      expect(msg).toMatchObject({
+        type: SERVER_MESSAGE_TYPE.MESSAGE,
+        username: "regular-user",
+        text: "/unblock 10.0.0.50",
+      });
+
+      ws.close();
+      ws2.close();
+    });
+
+    it("admin unknown /command sends as regular chat message", async () => {
+      const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+        token: "test-admin-secret",
+      });
+      const { ws: otherWs, msgs: otherMsgs } = await connectAndJoin("viewer");
+
+      adminMsgs.length = 0;
+      otherMsgs.length = 0;
+
+      send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/nonexistent" } });
+      await flush();
+
+      const msg = otherMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      expect(msg).toMatchObject({
+        type: SERVER_MESSAGE_TYPE.MESSAGE,
+        username: "thalida",
+        text: "/nonexistent",
+      });
+
+      adminWs.close();
+      otherWs.close();
+    });
+  });
+```
+
+**Step 2: Update the existing non-owner `/unblock` test**
+
+The existing test "non-owner /unblock command returns unauthorized error" now expects the message to be sent as regular text instead of returning an error. Replace the test body in the "IP blocking" describe block:
+
+```ts
+    it("non-owner /unblock command sends as regular chat message", async () => {
+      const { ws, msgs } = await connectAndJoin("regular-user", { ip: "10.0.0.2" });
+      const { ws: ws2, msgs: msgs2 } = await connectAndJoin("watcher", { ip: "10.0.0.3" });
+
+      msgs.length = 0;
+      msgs2.length = 0;
+
+      send(ws, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/unblock 10.0.0.50" } });
+      await flush();
+
+      const chatMsg = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+      expect(chatMsg).toMatchObject({
+        type: SERVER_MESSAGE_TYPE.MESSAGE,
+        username: "regular-user",
+        text: "/unblock 10.0.0.50",
+      });
+
+      ws.close();
+      ws2.close();
+    });
+```
+
+**Step 3: Run the tests**
+
+Run: `just api::test`
+Expected: All tests pass.
+
+**Step 4: Commit**
+
+```bash
+git add api/src/__tests__/chat-room.test.ts
+git commit -m "test(api): add tests for admin command registry and /help"
+```
+
+---
+
+### Task 5: Handle the `help` message type on the client
+
+**Files:**
+- Modify: `app/src/components/Chat/chat-client.ts`
+
+**Step 1: Add `HELP` to the client's `SERVER_MESSAGE_TYPE`**
+
+```ts
+const SERVER_MESSAGE_TYPE = {
+  ERROR: "error",
+  WARNING: "warning",
+  BLOCKED: "blocked",
+  UNBLOCKED: "unblocked",
+  HELP: "help",
+  JOINED: "joined",
+  STATUS: "status",
+  HISTORY: "history",
+  REMOVE: "remove",
+  MESSAGE: "message",
+} as const;
+```
+
+**Step 2: Add `help` to the `ServerMessage` type**
+
+Add to the `ServerMessage` union:
+
+```ts
+  | { type: "help"; commands: Array<{ name: string; description: string }> }
+```
+
+**Step 3: Add handler in the message event listener**
+
+After the `unblocked` handler, add:
+
+```ts
+    } else if (data.type === SERVER_MESSAGE_TYPE.HELP) {
+      const lines = data.commands.map((c) => `  /${c.name} — ${c.description}`);
+      appendNotice(`Available commands:\n${lines.join("\n")}`);
+    }
+```
+
+**Step 4: Commit**
+
+```bash
+git add app/src/components/Chat/chat-client.ts
+git commit -m "feat(app): handle HELP message type in chat client"
+```
+
+---
+
+### Task 6: Verify end-to-end and run all tests
+
+**Step 1: Run API tests**
+
+Run: `just api::test`
+Expected: All tests pass including new admin command tests.
+
+**Step 2: Run API typecheck**
+
+Run: `just api::typecheck`
+Expected: No type errors.
+
+**Step 3: Run app typecheck**
+
+Run: `just app::typecheck`
+Expected: No type errors.
+
+**Step 4: Run app build**
+
+Run: `just app::build`
+Expected: Build succeeds.
+
+**Step 5: Final commit (if any fixups needed)**
+
+Only if previous steps required changes.

--- a/docs/plans/2026-02-28-admin-moderation-tools-design.md
+++ b/docs/plans/2026-02-28-admin-moderation-tools-design.md
@@ -1,0 +1,116 @@
+# Admin Moderation Tools — Design
+
+## Goal
+
+Add three admin moderation features to the chat: a delete message button, a flag/ban button, and a `/blocked` command to list all blocked users.
+
+## Key Decisions
+
+- **Server-side auth on everything**: All actions (delete, flag) require `isOwner` validation on the server. Client-side button hiding is cosmetic only. Unauthorized requests are silently ignored — no error, no hint the action exists.
+- **Delete has click-to-confirm UX**: First click shows confirm state, second click deletes.
+- **Flag bans first, then asks about message deletion**: Admin sees a system notice with choices: delete all messages, delete just the flagged message, or keep messages.
+- **Blocked list stores username + IP**: Migrate storage from `string[]` to structured entries with username and timestamp.
+- **All new actions use existing patterns**: `REMOVE` broadcast for deletions, command registry for `/blocked`, system notices for admin feedback.
+
+## Feature 1: Delete Message Button
+
+### Server
+
+- New client message type `DELETE`: `{ type: "delete", data: { id: string } }`
+- Handler in `ChatRoom`: validates `isOwner`, removes message from `this.messages` by ID, broadcasts `REMOVE` (existing type) to all clients
+- Non-owner `DELETE` requests are silently ignored (no response)
+- New public method `handleDeleteMessage(ws, messageId)` exposed for the client message handler
+
+### Client
+
+- Message template gains a delete button (trash icon), hidden by default
+- When `isOwner` is true after join, admin controls are revealed on all messages
+- Click 1: button enters confirm state (visual change — red/highlighted)
+- Click 2: sends `{ type: "delete", data: { id } }` to server
+- Message removal happens via the existing `REMOVE` handler (already implemented)
+
+## Feature 2: Flag/Ban Button
+
+### Server
+
+- New client message type `FLAG`: `{ type: "flag", data: { id: string } }`
+- Handler in `ChatRoom`: validates `isOwner`, looks up the message by ID to find the username, finds all connections with that username to get the IP
+- Adds IP to blockedIps (with username + timestamp), persists
+- Sends `BLOCKED` message to the flagged user's socket(s), closes their connections
+- Responds to admin with new `FLAGGED` message: `{ type: "flagged", username: string, ip: string, messageId: string }`
+- Non-owner `FLAG` requests are silently ignored
+
+- New client message type `DELETE_BY_USER`: `{ type: "delete_by_user", data: { username: string } }`
+- Handler: validates `isOwner`, removes all messages from `this.messages` where `msg.username === username`, broadcasts `REMOVE` for each removed message ID
+
+### Client
+
+- Message template gains a flag button (flag icon) next to the delete button, hidden by default
+- Shown when `isOwner` is true
+- Click shows confirm state (like delete)
+- On confirm, sends `{ type: "flag", data: { id } }` to server
+- On receiving `FLAGGED` response, shows a system notice:
+  ```
+  Banned [username] ([ip]).
+  Delete their messages? [all] [this one] [none]
+  ```
+- "all" sends `{ type: "delete_by_user", data: { username } }`
+- "this one" sends `{ type: "delete", data: { id: messageId } }`
+- "none" dismisses the notice (no action)
+- The clickable options are styled spans inside the notice
+
+## Feature 3: `/blocked` Command
+
+### Server
+
+- Register `/blocked` command in the command registry
+- New server message type `BLOCKED_LIST`: `{ type: "blocked_list", entries: Array<{ ip: string, username: string, blockedAt: number }> }`
+- Handler reads the blocked entries and sends them to the admin socket
+
+### Client
+
+- Handle `blocked_list` message type
+- Render as system notice listing each entry:
+  ```
+  Blocked users:
+    [username] — [ip] (blocked [date])
+    [username] — [ip] (blocked [date])
+  ```
+
+### Storage Migration
+
+Current format: `blockedIps` stored as `string[]` (IPs only).
+
+New format: stored as `Array<{ ip: string, username: string, blockedAt: number }>`.
+
+Migration on load:
+- If stored data is `string[]` (old format), convert each IP to `{ ip, username: "unknown", blockedAt: 0 }`
+- If stored data is the new format, use directly
+- All new blocks store the full entry going forward
+
+## New Client Message Types
+
+```ts
+// Added to CLIENT_MESSAGE_TYPE
+DELETE: "delete"
+FLAG: "flag"
+DELETE_BY_USER: "delete_by_user"
+```
+
+## New Server Message Types
+
+```ts
+// Added to SERVER_MESSAGE_TYPE
+FLAGGED: "flagged"
+BLOCKED_LIST: "blocked_list"
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `api/src/types.ts` | New client types (DELETE, FLAG, DELETE_BY_USER), new server types (FLAGGED, BLOCKED_LIST), updated ClientMessage union |
+| `api/src/commands.ts` | Register `/blocked` command |
+| `api/src/chat-room.ts` | Handle delete/flag/delete_by_user, migrate blockedIps storage, new public methods |
+| `app/src/components/Chat/Chat.astro` | Add delete/flag buttons to message template, styles for confirm state |
+| `app/src/components/Chat/chat-client.ts` | Handle new server message types, admin button logic, flagged notice with clickable choices, new client message sending |

--- a/docs/plans/2026-02-28-admin-moderation-tools.md
+++ b/docs/plans/2026-02-28-admin-moderation-tools.md
@@ -1,0 +1,1012 @@
+# Admin Moderation Tools Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add admin-only delete message button, flag/ban button, and `/blocked` command to the chat system.
+
+**Architecture:** Three new client message types (DELETE, FLAG, DELETE_BY_USER) and two new server message types (FLAGGED, BLOCKED_LIST) extend the existing WebSocket protocol. The blockedIps storage migrates from `string[]` to structured entries with username/timestamp. Admin buttons are added to the message template, hidden for non-admins. All actions are server-validated — unauthorized requests are silently ignored.
+
+**Tech Stack:** TypeScript, Cloudflare Workers/Durable Objects, Vitest, Astro, Tailwind CSS
+
+---
+
+### Task 1: Add all new types
+
+**Files:**
+- Modify: `api/src/types.ts`
+
+**Step 1: Add new client message types and data interfaces**
+
+Add `DELETE`, `FLAG`, and `DELETE_BY_USER` to `CLIENT_MESSAGE_TYPE` (after `MESSAGE`):
+
+```ts
+export const CLIENT_MESSAGE_TYPE = {
+  JOIN: "join",
+  MESSAGE: "message",
+  DELETE: "delete",
+  FLAG: "flag",
+  DELETE_BY_USER: "delete_by_user",
+} as const;
+```
+
+Add data interfaces after `ClientChatData`:
+
+```ts
+export interface ClientDeleteData {
+  id: string;
+}
+
+export interface ClientFlagData {
+  id: string;
+}
+
+export interface ClientDeleteByUserData {
+  username: string;
+}
+```
+
+Update the `ClientMessage` union:
+
+```ts
+export type ClientMessage =
+  | { type: "join"; data: ClientJoinData }
+  | { type: "message"; data: ClientChatData }
+  | { type: "delete"; data: ClientDeleteData }
+  | { type: "flag"; data: ClientFlagData }
+  | { type: "delete_by_user"; data: ClientDeleteByUserData };
+```
+
+**Step 2: Add new server message types**
+
+Add `FLAGGED` and `BLOCKED_LIST` to `SERVER_MESSAGE_TYPE` (after `HELP`):
+
+```ts
+export const SERVER_MESSAGE_TYPE = {
+  ERROR: "error",
+  WARNING: "warning",
+  BLOCKED: "blocked",
+  UNBLOCKED: "unblocked",
+  HELP: "help",
+  FLAGGED: "flagged",
+  BLOCKED_LIST: "blocked_list",
+  JOINED: "joined",
+  STATUS: "status",
+  HISTORY: "history",
+  REMOVE: "remove",
+  MESSAGE: "message",
+} as const;
+```
+
+Add interfaces after `ServerHelpMessage`:
+
+```ts
+export interface ServerFlaggedMessage {
+  type: "flagged";
+  username: string;
+  ip: string;
+  messageId: string;
+}
+
+export interface BlockedEntry {
+  ip: string;
+  username: string;
+  blockedAt: number;
+}
+
+export interface ServerBlockedListMessage {
+  type: "blocked_list";
+  entries: BlockedEntry[];
+}
+```
+
+Update the `ServerMessage` union:
+
+```ts
+export type ServerMessage =
+  | ServerErrorResponse
+  | ServerBroadcast
+  | ServerJoinedMessage
+  | ServerUnblockedMessage
+  | ServerHelpMessage
+  | ServerFlaggedMessage
+  | ServerBlockedListMessage
+  | ChatMessage;
+```
+
+**Step 3: Commit**
+
+```bash
+git add api/src/types.ts
+git commit -m "feat(api): add types for delete, flag, delete_by_user, and blocked_list"
+```
+
+---
+
+### Task 2: Migrate blockedIps storage format
+
+**Files:**
+- Modify: `api/src/chat-room.ts`
+
+**Step 1: Change the in-memory data structure**
+
+Replace the `blockedIps` field and related methods in `ChatRoom`:
+
+Change:
+```ts
+private blockedIps: Set<string> = new Set();
+```
+To:
+```ts
+private blockedEntries: Map<string, { username: string; blockedAt: number }> = new Map();
+```
+
+**Step 2: Update `loadBlockedIps` with migration logic**
+
+Replace the `loadBlockedIps` method:
+
+```ts
+private async loadBlockedIps(): Promise<void> {
+  if (this.blockedIpsLoaded) return;
+  const stored = await this.state.storage.get<unknown>(BLOCKED_IPS_KEY);
+  if (Array.isArray(stored)) {
+    for (const entry of stored) {
+      if (typeof entry === "string") {
+        // Old format: plain IP strings
+        this.blockedEntries.set(entry, { username: "unknown", blockedAt: 0 });
+      } else if (entry && typeof entry === "object" && "ip" in entry) {
+        // New format: { ip, username, blockedAt }
+        const e = entry as { ip: string; username: string; blockedAt: number };
+        this.blockedEntries.set(e.ip, { username: e.username, blockedAt: e.blockedAt });
+      }
+    }
+  }
+  this.blockedIpsLoaded = true;
+}
+```
+
+**Step 3: Update `persistBlockedIps`**
+
+```ts
+private async persistBlockedIps(): Promise<void> {
+  const entries = [...this.blockedEntries.entries()].map(([ip, info]) => ({
+    ip,
+    username: info.username,
+    blockedAt: info.blockedAt,
+  }));
+  await this.state.storage.put(BLOCKED_IPS_KEY, entries);
+}
+```
+
+**Step 4: Update all references from `this.blockedIps` to `this.blockedEntries`**
+
+In `fetch()` method, change:
+```ts
+if (this.blockedIps.has(ip)) {
+```
+To:
+```ts
+if (this.blockedEntries.has(ip)) {
+```
+
+In `addWarning()`, change:
+```ts
+this.blockedIps.add(info.ip);
+```
+To:
+```ts
+this.blockedEntries.set(info.ip, { username: info.username, blockedAt: Date.now() });
+```
+
+In `handleUnblock()`, change:
+```ts
+this.blockedIps.delete(ip);
+```
+To:
+```ts
+this.blockedEntries.delete(ip);
+```
+
+**Step 5: Add `BlockedEntry` to the imports from types**
+
+Add `BlockedEntry` to the type imports at the top of `chat-room.ts`.
+
+**Step 6: Run tests to verify migration doesn't break existing behavior**
+
+Run: `just api::test`
+Expected: All existing tests pass (the test environment starts fresh each time, no persisted data to migrate).
+
+**Step 7: Commit**
+
+```bash
+git add api/src/chat-room.ts
+git commit -m "feat(api): migrate blockedIps storage to structured entries with username and timestamp"
+```
+
+---
+
+### Task 3: Server — Admin delete message
+
+**Files:**
+- Modify: `api/src/chat-room.ts`
+- Modify: `api/src/__tests__/chat-room.test.ts`
+
+**Step 1: Write failing tests for delete**
+
+Add a new describe block `"admin delete"` in the test file after the `"admin commands"` block:
+
+```ts
+describe("admin delete", () => {
+  it("admin can delete a message by ID", async () => {
+    const { ws: userWs, msgs: userMsgs } = await connectAndJoin("chatter");
+    const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      token: "test-admin-secret",
+    });
+
+    userMsgs.length = 0;
+    adminMsgs.length = 0;
+
+    send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "delete me" } });
+    await flush();
+
+    const chatMsg = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+    expect(chatMsg).toBeDefined();
+    const msgId = chatMsg!.type === SERVER_MESSAGE_TYPE.MESSAGE ? (chatMsg as any).id : undefined;
+    expect(msgId).toBeDefined();
+
+    adminMsgs.length = 0;
+    userMsgs.length = 0;
+
+    send(adminWs, { type: "delete", data: { id: msgId } });
+    await flush();
+
+    const remove1 = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+    const remove2 = userMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+    expect(remove1).toMatchObject({ type: SERVER_MESSAGE_TYPE.REMOVE, id: msgId });
+    expect(remove2).toMatchObject({ type: SERVER_MESSAGE_TYPE.REMOVE, id: msgId });
+
+    userWs.close();
+    adminWs.close();
+  });
+
+  it("non-admin delete request is silently ignored", async () => {
+    const { ws: ws1, msgs: msgs1 } = await connectAndJoin("sender");
+    const { ws: ws2, msgs: msgs2 } = await connectAndJoin("hacker");
+
+    msgs1.length = 0;
+    msgs2.length = 0;
+
+    send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "stay here" } });
+    await flush();
+
+    const chatMsg = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+    const msgId = chatMsg!.type === SERVER_MESSAGE_TYPE.MESSAGE ? (chatMsg as any).id : undefined;
+
+    msgs1.length = 0;
+    msgs2.length = 0;
+
+    send(ws2, { type: "delete", data: { id: msgId } });
+    await flush();
+
+    // No REMOVE broadcast should happen
+    const remove = msgs1.find((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+    expect(remove).toBeUndefined();
+
+    ws1.close();
+    ws2.close();
+  });
+
+  it("delete of nonexistent message ID is silently ignored", async () => {
+    const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      token: "test-admin-secret",
+    });
+
+    adminMsgs.length = 0;
+
+    send(adminWs, { type: "delete", data: { id: "nonexistent-id" } });
+    await flush();
+
+    const remove = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+    expect(remove).toBeUndefined();
+
+    adminWs.close();
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `just api::test`
+Expected: New tests fail (delete message type not handled yet).
+
+**Step 3: Implement delete handler in ChatRoom**
+
+In `handleMessage`, add a new case to the switch:
+
+```ts
+case CLIENT_MESSAGE_TYPE.DELETE:
+  this.handleDelete(ws, msg.data);
+  break;
+```
+
+Add the handler method after `handleUnblock`:
+
+```ts
+private handleDelete(ws: WebSocket, { id }: ClientDeleteData): void {
+  const info = this.connections.get(ws);
+  if (!info?.isOwner) return;
+
+  const idx = this.messages.findIndex((m) => m.id === id);
+  if (idx === -1) return;
+
+  this.messages.splice(idx, 1);
+  this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id });
+}
+```
+
+Add `ClientDeleteData` to the imports from `./types`. Also update the `ClientMessage` type reference if needed — the switch/case should already work with the updated union type.
+
+**Step 4: Add public method for command interface**
+
+```ts
+handleDeleteMessage(ws: WebSocket, messageId: string): void {
+  this.handleDelete(ws, { id: messageId });
+}
+```
+
+**Step 5: Run tests**
+
+Run: `just api::test`
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add api/src/chat-room.ts api/src/__tests__/chat-room.test.ts
+git commit -m "feat(api): add admin delete message handler with tests"
+```
+
+---
+
+### Task 4: Server — Admin flag/ban
+
+**Files:**
+- Modify: `api/src/chat-room.ts`
+- Modify: `api/src/__tests__/chat-room.test.ts`
+
+**Step 1: Write failing tests for flag**
+
+Add a new describe block `"admin flag"` after `"admin delete"`:
+
+```ts
+describe("admin flag", () => {
+  it("admin can flag a user, which blocks their IP and responds with FLAGGED", async () => {
+    const { ws: userWs, msgs: userMsgs } = await connectAndJoin("bad-user", { ip: "10.0.0.99" });
+    const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      token: "test-admin-secret",
+      ip: "10.0.0.1",
+    });
+
+    userMsgs.length = 0;
+    adminMsgs.length = 0;
+
+    send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "offensive content" } });
+    await flush();
+
+    const chatMsg = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+    const msgId = chatMsg!.type === SERVER_MESSAGE_TYPE.MESSAGE ? (chatMsg as any).id : undefined;
+
+    adminMsgs.length = 0;
+    userMsgs.length = 0;
+
+    send(adminWs, { type: "flag", data: { id: msgId } });
+    await flush();
+
+    // Admin receives FLAGGED response
+    const flagged = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.FLAGGED);
+    expect(flagged).toMatchObject({
+      type: SERVER_MESSAGE_TYPE.FLAGGED,
+      username: "bad-user",
+      ip: "10.0.0.99",
+      messageId: msgId,
+    });
+
+    // User receives BLOCKED
+    const blocked = userMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.BLOCKED);
+    expect(blocked).toBeDefined();
+
+    adminWs.close();
+    userWs.close();
+  });
+
+  it("non-admin flag request is silently ignored", async () => {
+    const { ws: ws1, msgs: msgs1 } = await connectAndJoin("target", { ip: "10.0.0.10" });
+    const { ws: ws2, msgs: msgs2 } = await connectAndJoin("hacker", { ip: "10.0.0.11" });
+
+    msgs1.length = 0;
+    msgs2.length = 0;
+
+    send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "normal message" } });
+    await flush();
+
+    const chatMsg = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+    const msgId = chatMsg!.type === SERVER_MESSAGE_TYPE.MESSAGE ? (chatMsg as any).id : undefined;
+
+    msgs1.length = 0;
+    msgs2.length = 0;
+
+    send(ws2, { type: "flag", data: { id: msgId } });
+    await flush();
+
+    // No FLAGGED or BLOCKED messages should appear
+    const flagged = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.FLAGGED);
+    expect(flagged).toBeUndefined();
+    const blocked = msgs1.find((m) => m.type === SERVER_MESSAGE_TYPE.BLOCKED);
+    expect(blocked).toBeUndefined();
+
+    ws1.close();
+    ws2.close();
+  });
+
+  it("flagging nonexistent message ID is silently ignored", async () => {
+    const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      token: "test-admin-secret",
+    });
+
+    adminMsgs.length = 0;
+
+    send(adminWs, { type: "flag", data: { id: "nonexistent-id" } });
+    await flush();
+
+    const flagged = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.FLAGGED);
+    expect(flagged).toBeUndefined();
+
+    adminWs.close();
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `just api::test`
+
+**Step 3: Implement flag handler**
+
+In `handleMessage`, add a case:
+
+```ts
+case CLIENT_MESSAGE_TYPE.FLAG:
+  this.handleFlag(ws, msg.data);
+  break;
+```
+
+Add the handler after `handleDelete`:
+
+```ts
+private handleFlag(ws: WebSocket, { id }: ClientFlagData): void {
+  const info = this.connections.get(ws);
+  if (!info?.isOwner) return;
+
+  const message = this.messages.find((m) => m.id === id);
+  if (!message) return;
+
+  const targetUsername = message.username;
+
+  // Find the target's IP from their connection
+  let targetIp: string | undefined;
+  for (const [, connInfo] of this.connections) {
+    if (connInfo.username === targetUsername && !connInfo.isOwner) {
+      targetIp = connInfo.ip;
+      break;
+    }
+  }
+
+  if (!targetIp) return;
+
+  // Block the IP
+  this.blockedEntries.set(targetIp, { username: targetUsername, blockedAt: Date.now() });
+  this.persistBlockedIps().catch((err) => {
+    console.error("[flag] failed to persist blocked IP:", err);
+  });
+
+  // Send BLOCKED to all of the target's sockets and close them
+  for (const [targetWs, connInfo] of this.connections) {
+    if (connInfo.ip === targetIp && !connInfo.isOwner) {
+      this.sendBlocked(
+        targetWs,
+        SERVER_ERROR_CODE.MODERATION_BLOCKED,
+        "You have been blocked by the admin.",
+      );
+      connInfo.isBlocked = true;
+    }
+  }
+
+  // Respond to admin
+  this.send(ws, {
+    type: SERVER_MESSAGE_TYPE.FLAGGED,
+    username: targetUsername,
+    ip: targetIp,
+    messageId: id,
+  });
+}
+```
+
+Add `ClientFlagData` to the imports from `./types`.
+
+**Step 4: Run tests**
+
+Run: `just api::test`
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add api/src/chat-room.ts api/src/__tests__/chat-room.test.ts
+git commit -m "feat(api): add admin flag/ban handler with tests"
+```
+
+---
+
+### Task 5: Server — Delete messages by username
+
+**Files:**
+- Modify: `api/src/chat-room.ts`
+- Modify: `api/src/__tests__/chat-room.test.ts`
+
+**Step 1: Write failing tests**
+
+Add to the `"admin delete"` describe block:
+
+```ts
+it("admin can delete all messages from a username", async () => {
+  const { ws: userWs } = await connectAndJoin("spammer");
+  const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+    token: "test-admin-secret",
+  });
+
+  // Send multiple messages
+  send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "spam 1" } });
+  send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "spam 2" } });
+  send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "spam 3" } });
+  await flush();
+
+  adminMsgs.length = 0;
+
+  send(adminWs, { type: "delete_by_user", data: { username: "spammer" } });
+  await flush();
+
+  // Should receive REMOVE for each deleted message
+  const removes = adminMsgs.filter((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+  expect(removes).toHaveLength(3);
+
+  userWs.close();
+  adminWs.close();
+});
+
+it("non-admin delete_by_user is silently ignored", async () => {
+  const { ws: ws1 } = await connectAndJoin("poster");
+  const { ws: ws2, msgs: msgs2 } = await connectAndJoin("hacker");
+
+  send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "keep this" } });
+  await flush();
+
+  msgs2.length = 0;
+
+  send(ws2, { type: "delete_by_user", data: { username: "poster" } });
+  await flush();
+
+  const removes = msgs2.filter((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+  expect(removes).toHaveLength(0);
+
+  ws1.close();
+  ws2.close();
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `just api::test`
+
+**Step 3: Implement delete_by_user handler**
+
+In `handleMessage`, add a case:
+
+```ts
+case CLIENT_MESSAGE_TYPE.DELETE_BY_USER:
+  this.handleDeleteByUser(ws, msg.data);
+  break;
+```
+
+Add the handler:
+
+```ts
+private handleDeleteByUser(ws: WebSocket, { username: targetUsername }: ClientDeleteByUserData): void {
+  const info = this.connections.get(ws);
+  if (!info?.isOwner) return;
+
+  const toRemove = this.messages.filter((m) => m.username === targetUsername);
+  this.messages = this.messages.filter((m) => m.username !== targetUsername);
+
+  for (const msg of toRemove) {
+    this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id: msg.id });
+  }
+}
+```
+
+Add `ClientDeleteByUserData` to the imports from `./types`.
+
+**Step 4: Run tests**
+
+Run: `just api::test`
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add api/src/chat-room.ts api/src/__tests__/chat-room.test.ts
+git commit -m "feat(api): add admin delete-by-user handler with tests"
+```
+
+---
+
+### Task 6: Server — `/blocked` command
+
+**Files:**
+- Modify: `api/src/commands.ts`
+- Modify: `api/src/chat-room.ts`
+- Modify: `api/src/__tests__/chat-room.test.ts`
+
+**Step 1: Write failing test**
+
+Add to the `"admin commands"` describe block:
+
+```ts
+it("admin /blocked returns list of blocked entries", async () => {
+  // First, create a blocked user by having admin flag someone
+  const { ws: userWs, msgs: userMsgs } = await connectAndJoin("troublemaker", { ip: "10.0.0.77" });
+  const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+    token: "test-admin-secret",
+    ip: "10.0.0.1",
+  });
+
+  send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "bad stuff" } });
+  await flush();
+
+  const chatMsg = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+  const msgId = chatMsg!.type === SERVER_MESSAGE_TYPE.MESSAGE ? (chatMsg as any).id : undefined;
+
+  send(adminWs, { type: "flag", data: { id: msgId } });
+  await flush();
+
+  adminMsgs.length = 0;
+
+  // Now ask for the blocked list
+  send(adminWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "/blocked" } });
+  await flush();
+
+  const list = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.BLOCKED_LIST);
+  expect(list).toBeDefined();
+  if (list && list.type === SERVER_MESSAGE_TYPE.BLOCKED_LIST) {
+    expect(list.entries.length).toBeGreaterThanOrEqual(1);
+    const entry = list.entries.find((e) => e.ip === "10.0.0.77");
+    expect(entry).toBeDefined();
+    expect(entry!.username).toBe("troublemaker");
+    expect(entry!.blockedAt).toBeGreaterThan(0);
+  }
+
+  adminWs.close();
+  userWs.close();
+});
+```
+
+**Step 2: Run tests to verify it fails**
+
+Run: `just api::test`
+
+**Step 3: Add public method to ChatRoom for getting blocked entries**
+
+Add to the Command Interface section of `chat-room.ts`:
+
+```ts
+getBlockedEntries(): BlockedEntry[] {
+  return [...this.blockedEntries.entries()].map(([ip, info]) => ({
+    ip,
+    username: info.username,
+    blockedAt: info.blockedAt,
+  }));
+}
+```
+
+**Step 4: Register `/blocked` command**
+
+In `api/src/commands.ts`, add after the `/unblock` registration:
+
+```ts
+register({
+  name: "blocked",
+  description: "List all blocked users and IPs",
+  handler: (ws, _args, chatRoom) => {
+    chatRoom.sendToSocket(ws, {
+      type: SERVER_MESSAGE_TYPE.BLOCKED_LIST,
+      entries: chatRoom.getBlockedEntries(),
+    });
+  },
+});
+```
+
+**Step 5: Run tests**
+
+Run: `just api::test`
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add api/src/commands.ts api/src/chat-room.ts api/src/__tests__/chat-room.test.ts
+git commit -m "feat(api): add /blocked command to list blocked users"
+```
+
+---
+
+### Task 7: Client — Add admin control buttons to message template
+
+**Files:**
+- Modify: `app/src/components/Chat/Chat.astro`
+
+**Step 1: Add delete and flag buttons to the message template**
+
+Replace the message template in `Chat.astro`:
+
+```html
+<template id="chat-msg-tpl">
+  <div class="group mb-2" data-msg-id="">
+    <div class="flex items-baseline gap-1.5 text-xs leading-tight">
+      <span data-chat="username" class="font-semibold text-teal data-admin:text-neon"></span>
+      <span class="ml-auto flex items-baseline gap-1.5 whitespace-nowrap">
+        <span data-chat="admin-controls" hidden class="inline-flex gap-1">
+          <button data-chat="delete-btn" class="text-muted hover:text-red-400 transition-colors" type="button" title="Delete message">
+            <i class="fa-solid fa-trash-can fa-xs" aria-hidden="true"></i>
+          </button>
+          <button data-chat="flag-btn" class="text-muted hover:text-orange-400 transition-colors" type="button" title="Flag & ban user">
+            <i class="fa-solid fa-flag fa-xs" aria-hidden="true"></i>
+          </button>
+        </span>
+        <a data-chat="page" hidden class="text-text font-medium underline hover:text-teal" href=""></a>
+        <span data-chat="sep" hidden class="opacity-40">·</span>
+        <span data-chat="time" class="opacity-40"></span>
+      </span>
+    </div>
+    <div data-chat="text"></div>
+  </div>
+</template>
+```
+
+**Step 2: Add styles for confirm states**
+
+Add to the `<style>` block:
+
+```css
+[data-chat="delete-btn"][data-confirm] {
+  color: var(--color-red-400, #f87171);
+}
+[data-chat="flag-btn"][data-confirm] {
+  color: var(--color-orange-400, #fb923c);
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add app/src/components/Chat/Chat.astro
+git commit -m "feat(app): add admin delete and flag buttons to message template"
+```
+
+---
+
+### Task 8: Client — Wire up admin controls and new message handlers
+
+**Files:**
+- Modify: `app/src/components/Chat/chat-client.ts`
+
+**Step 1: Add new client message types**
+
+Update the client's `CLIENT_MESSAGE_TYPE`:
+
+```ts
+const CLIENT_MESSAGE_TYPE = {
+  JOIN: "join",
+  MESSAGE: "message",
+  DELETE: "delete",
+  FLAG: "flag",
+  DELETE_BY_USER: "delete_by_user",
+} as const;
+```
+
+**Step 2: Add new server message types**
+
+Update the client's `SERVER_MESSAGE_TYPE`:
+
+```ts
+const SERVER_MESSAGE_TYPE = {
+  ERROR: "error",
+  WARNING: "warning",
+  BLOCKED: "blocked",
+  UNBLOCKED: "unblocked",
+  HELP: "help",
+  FLAGGED: "flagged",
+  BLOCKED_LIST: "blocked_list",
+  JOINED: "joined",
+  STATUS: "status",
+  HISTORY: "history",
+  REMOVE: "remove",
+  MESSAGE: "message",
+} as const;
+```
+
+**Step 3: Add new types to the `ServerMessage` union**
+
+Add these variants:
+
+```ts
+  | { type: "flagged"; username: string; ip: string; messageId: string }
+  | { type: "blocked_list"; entries: Array<{ ip: string; username: string; blockedAt: number }> }
+```
+
+**Step 4: Update `appendMessage` to show admin controls and wire button handlers**
+
+After the line `slot("text").textContent = msg.text;` (and before `messagesEl.appendChild(frag);`), add:
+
+```ts
+  if (isOwner && !isAdmin) {
+    const controls = slot("admin-controls");
+    controls.hidden = false;
+
+    const deleteBtn = slot("delete-btn") as HTMLButtonElement;
+    const flagBtn = slot("flag-btn") as HTMLButtonElement;
+
+    deleteBtn.addEventListener("click", () => {
+      if (deleteBtn.dataset.confirm !== undefined) {
+        wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE, data: { id: msg.id } });
+        delete deleteBtn.dataset.confirm;
+      } else {
+        deleteBtn.dataset.confirm = "";
+        setTimeout(() => delete deleteBtn.dataset.confirm, 3000);
+      }
+    });
+
+    flagBtn.addEventListener("click", () => {
+      if (flagBtn.dataset.confirm !== undefined) {
+        wsSend({ type: CLIENT_MESSAGE_TYPE.FLAG, data: { id: msg.id } });
+        delete flagBtn.dataset.confirm;
+      } else {
+        flagBtn.dataset.confirm = "";
+        setTimeout(() => delete flagBtn.dataset.confirm, 3000);
+      }
+    });
+  }
+```
+
+Note: `isOwner` here refers to the module-level `isOwner` variable (whether the current user is the admin). `isAdmin` checks if the message author is the admin (so admin can't delete/flag their own messages). This logic already exists at line 113: `const isAdmin = adminUsername != null && msg.username === adminUsername;`.
+
+**Step 5: Extract a `wsSend` helper**
+
+Add a helper function near the top of the file (after the existing helpers like `sendJoin`):
+
+```ts
+function wsSend(data: Record<string, unknown>): void {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify(data));
+}
+```
+
+Update `sendMessage` to use this helper too if desired, but not required.
+
+**Step 6: Add `FLAGGED` handler with clickable choices**
+
+In the message event listener, after the `HELP` handler, add:
+
+```ts
+    } else if (data.type === SERVER_MESSAGE_TYPE.FLAGGED) {
+      const notice = appendInteractiveNotice(
+        `Banned ${data.username} (${data.ip}).\nDelete their messages?`,
+        [
+          { label: "all", action: () => wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE_BY_USER, data: { username: data.username } }) },
+          { label: "this one", action: () => wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE, data: { id: data.messageId } }) },
+          { label: "none", action: () => {} },
+        ],
+      );
+    } else if (data.type === SERVER_MESSAGE_TYPE.BLOCKED_LIST) {
+      if (data.entries.length === 0) {
+        appendNotice("No blocked users.");
+      } else {
+        const lines = data.entries.map((e) => {
+          const date = e.blockedAt > 0 ? new Date(e.blockedAt).toLocaleDateString() : "unknown date";
+          return `  ${e.username} — ${e.ip} (blocked ${date})`;
+        });
+        appendNotice(`Blocked users:\n${lines.join("\n")}`);
+      }
+    }
+```
+
+**Step 7: Add `appendInteractiveNotice` function**
+
+Add this function after `appendNotice`:
+
+```ts
+function appendInteractiveNotice(
+  text: string,
+  actions: Array<{ label: string; action: () => void }>,
+): HTMLElement {
+  const frag = noticeTpl.content.cloneNode(true) as DocumentFragment;
+  const root = frag.firstElementChild as HTMLElement;
+  root.textContent = "";
+
+  const textNode = document.createTextNode(text + "  ");
+  root.appendChild(textNode);
+
+  actions.forEach((a, i) => {
+    if (i > 0) root.appendChild(document.createTextNode(" · "));
+    const span = document.createElement("span");
+    span.textContent = `[${a.label}]`;
+    span.className = "cursor-pointer underline hover:text-teal not-italic";
+    span.addEventListener("click", () => {
+      a.action();
+      root.textContent = `${text} — ${a.label}`;
+    });
+    root.appendChild(span);
+  });
+
+  messagesEl.appendChild(frag);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+  return root;
+}
+```
+
+**Step 8: Update `updateAdminUI` to also show controls on existing messages**
+
+After the `isOwner` check updates the admin links and username input, add logic to reveal admin controls on all existing messages:
+
+```ts
+  const allControls = messagesEl.querySelectorAll('[data-chat="admin-controls"]');
+  for (const el of allControls) {
+    (el as HTMLElement).hidden = !isOwner;
+  }
+```
+
+Wait — this won't work because the buttons need event listeners. Instead, keep the approach where `appendMessage` conditionally shows controls at render time. When the admin reconnects, the `HISTORY` handler re-renders all messages via `appendMessage`, which will correctly show/hide controls based on the new `isOwner` state. No extra work needed.
+
+Remove this step — the `HISTORY` handler already calls `appendMessage` for each message, which checks `isOwner`.
+
+**Step 8 (actual): Commit**
+
+```bash
+git add app/src/components/Chat/chat-client.ts
+git commit -m "feat(app): wire admin delete/flag buttons and handle FLAGGED/BLOCKED_LIST messages"
+```
+
+---
+
+### Task 9: Verify end-to-end
+
+**Step 1: Run API tests**
+
+Run: `just api::test`
+Expected: All tests pass.
+
+**Step 2: Run API typecheck**
+
+Run: `just api::typecheck`
+Expected: No type errors.
+
+**Step 3: Run app typecheck**
+
+Run: `just app::typecheck`
+Expected: No type errors.
+
+**Step 4: Run app build**
+
+Run: `just app::build`
+Expected: Build succeeds.
+
+**Step 5: Final commit (if any fixups needed)**
+
+Only if previous steps required changes.

--- a/docs/plans/2026-03-01-clientid-identity-design.md
+++ b/docs/plans/2026-03-01-clientid-identity-design.md
@@ -1,0 +1,70 @@
+# Chat: clientId-Based Identity
+
+Replace IP-based identity with clientId throughout the chat system. This makes flag, block, delete-by-user, and rename all operate per-browser rather than per-IP, so users on the same network are independent.
+
+## Data Model
+
+### ChatMessage
+Add `clientId: string`. Stored on every message so flag/delete/rename can trace back to the originating browser.
+
+### ConnectionInfo
+Remove `ip`. The `clientId` field (already optional) becomes required.
+
+### BlockedEntry
+Change from `{ ip, username, blockedAt }` to `{ clientId, username, blockedAt }`.
+
+## Server (chat-room.ts)
+
+### Removals
+- `ipBySocket` map
+- `CF-Connecting-IP` header reads
+- `ConnectionInfo.ip`
+
+### blockedEntries
+Rekey from IP to clientId. On load, discard any old IP-keyed entries (no migration path).
+
+### handleJoin
+- Block check: `blockedEntries.has(clientId)` instead of IP lookup.
+- Rename detection: if a connection already exists with the same `clientId` but different username, treat this as a rename:
+  1. Update `msg.username` on all `this.messages` where `msg.clientId === clientId`
+  2. Broadcast `{ type: "rename", oldUsername, newUsername }` to all clients
+  3. Continue normal join flow
+
+### handleFlag
+1. Get `clientId` from the flagged message (`message.clientId`)
+2. Add `clientId` to `blockedEntries`
+3. Find all connections with that `clientId`, send BLOCKED
+
+### handleDeleteByUser
+Match `msg.clientId` instead of `msg.username`. Client sends `clientId` (from message data attribute) instead of username.
+
+### handleUnblock
+Unblock by clientId instead of IP.
+
+### addWarning
+Auto-block by clientId instead of IP.
+
+### buildStatusMessage
+Dedup by `clientId` directly (remove `ip:username` fallback).
+
+## Types (types.ts)
+
+- `ChatMessage`: add `clientId: string`
+- `ConnectionInfo`: remove `ip`, make `clientId` required
+- `BlockedEntry`: `ip` → `clientId`
+- `ClientDeleteByUserData`: `{ username }` → `{ clientId }`
+- `ClientUnblockData`: `{ ip }` → `{ clientId }`
+- Add `RENAME: "rename"` to `SERVER_MESSAGE_TYPE`
+- Add `ServerRenameMessage { type: "rename", oldUsername: string, newUsername: string }`
+- `ServerFlaggedMessage`: `ip` → `clientId`
+- `ServerUnblockedMessage`: `ip` → `clientId`
+- Add `ServerRenameMessage` to `ServerMessage` union
+
+## Client (chat-client.ts)
+
+- Store `clientId` from received messages as `data-client-id` on message DOM elements
+- Handle `"rename"`: query `[data-chat="username"]` spans, update text where it matches `oldUsername`
+- Flag callback: send `clientId` from element's data attribute
+- Delete-by-user: send `clientId` instead of username
+- Unblock: send `clientId` instead of IP
+- Blocked list display: show truncated clientId instead of IP

--- a/docs/plans/2026-03-01-clientid-identity-implementation.md
+++ b/docs/plans/2026-03-01-clientid-identity-implementation.md
@@ -1,0 +1,933 @@
+# clientId-Based Identity Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace IP-based identity with clientId throughout the chat system so flag, block, delete-by-user, and rename operate per-browser, and users on the same network are independent.
+
+**Architecture:** Store `clientId` on every `ChatMessage`. Rekey `blockedEntries` from IP to clientId. Remove all IP plumbing (`ipBySocket`, `CF-Connecting-IP`, `ConnectionInfo.ip`). Add a `rename` server message type broadcast when a user changes their username, so all clients update old messages in real time.
+
+**Tech Stack:** TypeScript, Cloudflare Durable Objects (API), Astro + vanilla TS (frontend), Vitest (tests)
+
+---
+
+### Task 1: Update types (types.ts)
+
+**Files:**
+- Modify: `api/src/types.ts`
+
+**Step 1: Add clientId to ChatMessage**
+
+```typescript
+// In ChatMessage interface (line 7-14), add clientId:
+export interface ChatMessage {
+  type: "message";
+  id: string;
+  clientId: string;
+  username: string;
+  text: string;
+  timestamp: number;
+  context?: MessageContext;
+}
+```
+
+**Step 2: Remove ip from ConnectionInfo, make clientId required**
+
+```typescript
+// Replace ConnectionInfo (line 16-23) with:
+export interface ConnectionInfo {
+  clientId: string;
+  username: string;
+  isOwner: boolean;
+  warnings: number;
+  isBlocked: boolean;
+}
+```
+
+**Step 3: Change ClientDeleteByUserData from username to clientId**
+
+```typescript
+// Replace ClientDeleteByUserData (line 57-59) with:
+export interface ClientDeleteByUserData {
+  clientId: string;
+}
+```
+
+**Step 4: Change ClientUnblockData from ip to clientId**
+
+```typescript
+// Replace ClientUnblockData (line 61-63) with:
+export interface ClientUnblockData {
+  clientId: string;
+}
+```
+
+**Step 5: Add RENAME to SERVER_MESSAGE_TYPE**
+
+```typescript
+// Add to SERVER_MESSAGE_TYPE object (after MESSAGE):
+  RENAME: "rename",
+```
+
+**Step 6: Add ServerRenameMessage interface**
+
+```typescript
+// After ServerFlaggedMessage (around line 164-169), add:
+export interface ServerRenameMessage {
+  type: "rename";
+  oldUsername: string;
+  newUsername: string;
+}
+```
+
+**Step 7: Update ServerFlaggedMessage — ip → clientId**
+
+```typescript
+export interface ServerFlaggedMessage {
+  type: "flagged";
+  username: string;
+  clientId: string;
+  messageId: string;
+}
+```
+
+**Step 8: Update BlockedEntry — ip → clientId**
+
+```typescript
+export interface BlockedEntry {
+  clientId: string;
+  username: string;
+  blockedAt: number;
+}
+```
+
+**Step 9: Update ServerUnblockedMessage — ip → clientId**
+
+```typescript
+export interface ServerUnblockedMessage {
+  type: "unblocked";
+  clientId: string;
+}
+```
+
+**Step 10: Add ServerRenameMessage to ServerMessage union**
+
+```typescript
+// In the ServerMessage union type, add:
+  | ServerRenameMessage
+```
+
+**Step 11: Run typecheck to see what breaks**
+
+Run: `just api::typecheck`
+Expected: Type errors in `chat-room.ts` and `commands.ts` (this is expected — we fix those next)
+
+**Step 12: Commit**
+
+```bash
+git add api/src/types.ts
+git commit -m "refactor(types): replace IP with clientId, add rename message type"
+```
+
+---
+
+### Task 2: Update server (chat-room.ts)
+
+**Files:**
+- Modify: `api/src/chat-room.ts`
+
+**Step 1: Remove ipBySocket map and rekey blockedEntries**
+
+Replace the class properties (lines 37-42):
+
+```typescript
+// Remove: private ipBySocket: Map<WebSocket, string> = new Map();
+// Change blockedEntries key from IP string to clientId string:
+private blockedEntries: Map<string, { username: string; blockedAt: number }> = new Map();
+```
+
+(blockedEntries type stays the same, just the key semantics change from IP to clientId.)
+
+**Step 2: Update loadBlockedIps → loadBlockedClients**
+
+Rename method and update to handle clientId-keyed entries. Drop old IP-keyed entries (no migration path):
+
+```typescript
+private async loadBlockedClients(): Promise<void> {
+  if (this.blockedIpsLoaded) return;
+  const stored = await this.state.storage.get<unknown>(BLOCKED_IPS_KEY);
+  if (Array.isArray(stored)) {
+    for (const entry of stored) {
+      if (entry && typeof entry === "object" && "clientId" in entry) {
+        const e = entry as { clientId: string; username: string; blockedAt: number };
+        this.blockedEntries.set(e.clientId, { username: e.username, blockedAt: e.blockedAt });
+      }
+      // Old IP-keyed entries (plain strings or {ip,...}) are silently dropped
+    }
+  }
+  this.blockedIpsLoaded = true;
+}
+```
+
+**Step 3: Update persistBlockedIps → persistBlockedClients**
+
+```typescript
+private async persistBlockedClients(): Promise<void> {
+  const entries = [...this.blockedEntries.entries()].map(([clientId, info]) => ({
+    clientId,
+    username: info.username,
+    blockedAt: info.blockedAt,
+  }));
+  await this.state.storage.put(BLOCKED_IPS_KEY, entries);
+}
+```
+
+(Keep using the same storage key `BLOCKED_IPS_KEY` to avoid needing a migration — the old data is simply dropped on next load.)
+
+**Step 4: Update fetch() — remove IP handling**
+
+Remove the `CF-Connecting-IP` header read and `ipBySocket` set. The connection starts as a spectator with no identity until join:
+
+```typescript
+async fetch(request: Request): Promise<Response> {
+  if (request.headers.get("Upgrade") !== "websocket") {
+    return new Response("Expected WebSocket", { status: 426 });
+  }
+
+  await this.loadBlockedClients();
+  this.cleanupExpiredReservations().catch((err) => {
+    console.error("[reservations] cleanup error:", err);
+  });
+
+  const [client, server] = Object.values(new WebSocketPair());
+
+  server.accept();
+
+  this.spectators.add(server);
+  this.sendStatus(server);
+
+  server.addEventListener("message", (event) => {
+    this.handleMessage(server, event.data);
+  });
+
+  server.addEventListener("close", () => {
+    this.removeConnection(server);
+  });
+
+  server.addEventListener("error", () => {
+    this.removeConnection(server);
+  });
+
+  return new Response(null, { status: 101, webSocket: client });
+}
+```
+
+**Step 5: Update handleJoin — clientId-based blocking and rename support**
+
+```typescript
+private async handleJoin(ws: WebSocket, { username, token, clientId }: ClientJoinData): Promise<void> {
+  const isOwner = typeof token === "string" && token.length > 0 && token === this.env.ADMIN_SECRET;
+
+  const resolvedClientId = clientId ?? crypto.randomUUID();
+  const isBlocked = !isOwner && this.blockedEntries.has(resolvedClientId);
+
+  const name = isOwner
+    ? ADMIN_USERNAME
+    : String(username ?? "")
+        .trim()
+        .toLowerCase();
+
+  const usernamePattern = new RegExp(`^[a-z0-9_\\-.]{${MIN_USERNAME_LENGTH},${MAX_USERNAME_LENGTH}}$`);
+  if (!usernamePattern.test(name)) {
+    this.sendError(
+      ws,
+      SERVER_ERROR_CODE.INVALID_USERNAME,
+      `Username must be ${MIN_USERNAME_LENGTH}-${MAX_USERNAME_LENGTH} characters: lowercase letters, numbers, hyphens, underscores, or dots.`,
+    );
+    return;
+  }
+
+  if (name.includes(ADMIN_USERNAME) && !isOwner) {
+    this.sendError(ws, SERVER_ERROR_CODE.RESERVED_USERNAME, "That name contains a reserved word.");
+    return;
+  }
+
+  for (const [existingWs, info] of this.connections) {
+    if (info.username === name && existingWs !== ws && !(isOwner && info.isOwner)) {
+      if (resolvedClientId && info.clientId === resolvedClientId) continue;
+      this.sendError(ws, SERVER_ERROR_CODE.TAKEN_USERNAME, "That name is already taken.");
+      return;
+    }
+  }
+
+  if (!isOwner && resolvedClientId) {
+    const reservation = await this.getReservation(name);
+    if (reservation) {
+      const expired = Date.now() - reservation.lastSeen > RESERVATION_DURATION_MS;
+      if (reservation.clientId === resolvedClientId && expired) {
+        this.sendError(ws, SERVER_ERROR_CODE.EXPIRED_USERNAME, "Your reserved username has expired.");
+        return;
+      }
+      if (reservation.clientId !== resolvedClientId && !expired) {
+        this.sendError(ws, SERVER_ERROR_CODE.TAKEN_USERNAME, "That name is already taken.");
+        return;
+      }
+    }
+    await this.upsertReservation(name, resolvedClientId);
+  }
+
+  // Detect rename: same clientId, different username
+  const existingConn = this.connections.get(ws);
+  const oldUsername = existingConn?.clientId === resolvedClientId ? existingConn.username : undefined;
+  const isRename = oldUsername != null && oldUsername !== name;
+
+  if (isRename) {
+    // Update all stored messages from this clientId
+    for (const msg of this.messages) {
+      if (msg.clientId === resolvedClientId) {
+        msg.username = name;
+      }
+    }
+    // Broadcast rename to all clients
+    this.broadcast({ type: SERVER_MESSAGE_TYPE.RENAME, oldUsername: oldUsername!, newUsername: name });
+  }
+
+  this.spectators.delete(ws);
+  this.connections.set(ws, {
+    clientId: resolvedClientId,
+    username: name,
+    isOwner,
+    warnings: 0,
+    isBlocked,
+  });
+
+  this.send(ws, { type: SERVER_MESSAGE_TYPE.JOINED, isOwner, username: name, isBlocked });
+  this.send(ws, { type: SERVER_MESSAGE_TYPE.HISTORY, messages: this.messages });
+  this.broadcastStatus();
+}
+```
+
+**Step 6: Update handleChatMessage — store clientId on message**
+
+```typescript
+private handleChatMessage(ws: WebSocket, { text: rawText, context }: ClientChatData): void {
+  const info = this.connections.get(ws);
+  if (!info) return;
+
+  const text = String(rawText ?? "")
+    .trim()
+    .slice(0, MAX_MESSAGE_LENGTH);
+  if (!text) return;
+
+  if (info.isOwner && text.startsWith("/")) {
+    if (dispatch(text, ws, this)) return;
+  }
+
+  const message: ChatMessage = {
+    type: SERVER_MESSAGE_TYPE.MESSAGE,
+    id: uuidv7(),
+    clientId: info.clientId,
+    username: info.username,
+    text,
+    timestamp: Date.now(),
+    ...(context?.path && /^\/[-a-z0-9._/]*$/.test(context.path) ? { context } : {}),
+  };
+
+  this.messages.push(message);
+  if (this.messages.length > MAX_MESSAGES) {
+    this.messages.shift();
+  }
+
+  this.broadcast(message);
+
+  this.moderate(message, ws).catch((err) => {
+    console.error("[moderation] unexpected error:", err);
+  });
+}
+```
+
+**Step 7: Update handleFlag — find target by clientId from message**
+
+```typescript
+private handleFlag(ws: WebSocket, { id }: ClientFlagData): void {
+  const info = this.connections.get(ws);
+  if (!info?.isOwner) return;
+
+  const message = this.messages.find((m) => m.id === id);
+  if (!message) return;
+
+  const targetClientId = message.clientId;
+  if (!targetClientId) return;
+
+  // Block the clientId
+  this.blockedEntries.set(targetClientId, { username: message.username, blockedAt: Date.now() });
+  this.persistBlockedClients().catch((err) => {
+    console.error("[flag] failed to persist blocked client:", err);
+  });
+
+  // Send BLOCKED to all of the target's sockets
+  for (const [targetWs, connInfo] of this.connections) {
+    if (connInfo.clientId === targetClientId && !connInfo.isOwner) {
+      this.sendBlocked(targetWs);
+      connInfo.isBlocked = true;
+    }
+  }
+
+  // Respond to admin
+  this.send(ws, {
+    type: SERVER_MESSAGE_TYPE.FLAGGED,
+    username: message.username,
+    clientId: targetClientId,
+    messageId: id,
+  });
+}
+```
+
+**Step 8: Update handleDeleteByUser — match by clientId**
+
+```typescript
+private handleDeleteByUser(ws: WebSocket, { clientId: targetClientId }: ClientDeleteByUserData): void {
+  const info = this.connections.get(ws);
+  if (!info?.isOwner) return;
+
+  const toRemove = this.messages.filter((m) => m.clientId === targetClientId);
+  this.messages = this.messages.filter((m) => m.clientId !== targetClientId);
+
+  for (const msg of toRemove) {
+    this.broadcast({ type: SERVER_MESSAGE_TYPE.REMOVE, id: msg.id });
+  }
+}
+```
+
+**Step 9: Update handleUnblock — clientId instead of IP**
+
+```typescript
+private handleUnblock(ws: WebSocket, clientId: string): void {
+  const info = this.connections.get(ws);
+  if (!info?.isOwner) {
+    this.sendError(ws, SERVER_ERROR_CODE.UNAUTHORIZED, "Only the owner can unblock users.");
+    return;
+  }
+
+  this.blockedEntries.delete(clientId);
+  this.persistBlockedClients().catch((err) => {
+    console.error("[unblock] failed to persist unblock:", err);
+  });
+  this.send(ws, { type: SERVER_MESSAGE_TYPE.UNBLOCKED, clientId });
+
+  for (const [sock, connInfo] of this.connections) {
+    if (connInfo.clientId === clientId && connInfo.isBlocked) {
+      connInfo.isBlocked = false;
+      this.send(sock, {
+        type: SERVER_MESSAGE_TYPE.JOINED,
+        isOwner: false,
+        username: connInfo.username,
+        isBlocked: false,
+      });
+      this.send(sock, {
+        type: SERVER_MESSAGE_TYPE.WARNING,
+        code: SERVER_ERROR_CODE.UNBLOCKED,
+        message: "You have been unblocked.",
+      });
+    }
+  }
+}
+```
+
+**Step 10: Update addWarning — block by clientId**
+
+```typescript
+private addWarning(ws: WebSocket): void {
+  const info = this.connections.get(ws);
+  if (!info) return;
+
+  info.warnings++;
+
+  if (info.warnings >= MAX_WARNINGS) {
+    info.isBlocked = true;
+    this.blockedEntries.set(info.clientId, { username: info.username, blockedAt: Date.now() });
+    this.persistBlockedClients().catch((err) => {
+      console.error("[block] failed to persist blocked client:", err);
+    });
+    this.sendBlocked(ws);
+  } else {
+    const remaining = MAX_WARNINGS - info.warnings;
+    this.sendWarning(
+      ws,
+      SERVER_ERROR_CODE.MODERATION_WARNING,
+      `Your message was removed for violating community guidelines. ${remaining} warning${remaining !== 1 ? "s" : ""} remaining before you are blocked.`,
+    );
+  }
+}
+```
+
+**Step 11: Update getBlockedEntries — return clientId**
+
+```typescript
+getBlockedEntries(): BlockedEntry[] {
+  return [...this.blockedEntries.entries()].map(([clientId, info]) => ({
+    clientId,
+    username: info.username,
+    blockedAt: info.blockedAt,
+  }));
+}
+```
+
+**Step 12: Update removeConnection — remove ipBySocket cleanup**
+
+```typescript
+private removeConnection(ws: WebSocket): void {
+  this.spectators.delete(ws);
+  this.connections.delete(ws);
+  this.broadcastStatus();
+}
+```
+
+**Step 13: Update buildStatusMessage — dedup by clientId**
+
+```typescript
+private buildStatusMessage(): ServerMessage {
+  let isOwnerOnline = false;
+  const uniqueClients = new Set<string>();
+  for (const info of this.connections.values()) {
+    if (info.isOwner) isOwnerOnline = true;
+    uniqueClients.add(info.clientId);
+  }
+  return { type: SERVER_MESSAGE_TYPE.STATUS, isOwnerOnline, userCount: uniqueClients.size };
+}
+```
+
+**Step 14: Update commands.ts description**
+
+In `api/src/commands.ts` line 29, change the description:
+
+```typescript
+description: "List all blocked users",
+```
+
+**Step 15: Run typecheck**
+
+Run: `just api::typecheck`
+Expected: PASS (no type errors)
+
+**Step 16: Commit**
+
+```bash
+git add api/src/chat-room.ts api/src/commands.ts
+git commit -m "refactor(api): replace IP with clientId for blocking, add rename support"
+```
+
+---
+
+### Task 3: Update client (chat-client.ts)
+
+**Files:**
+- Modify: `app/src/components/Chat/chat-client.ts`
+
+**Step 1: Update ServerMessage type — add rename, change ip → clientId**
+
+```typescript
+type ServerMessage =
+  | { type: "history"; messages: ChatMessage[] }
+  | {
+      type: "message";
+      id: string;
+      clientId: string;
+      username: string;
+      text: string;
+      timestamp: number;
+      context?: MessageContext;
+    }
+  | { type: "joined"; isOwner: boolean; username: string; isBlocked: boolean }
+  | { type: "status"; isOwnerOnline: boolean; userCount: number }
+  | { type: "error"; code: string; message: string }
+  | { type: "remove"; id: string }
+  | { type: "warning"; code: string; message: string }
+  | { type: "blocked"; code: string; message: string }
+  | { type: "unblocked"; clientId: string }
+  | { type: "help"; commands: Array<{ name: string; description: string }> }
+  | { type: "flagged"; username: string; clientId: string; messageId: string }
+  | { type: "blocked_list"; entries: Array<{ clientId: string; username: string; blockedAt: number }> }
+  | { type: "rename"; oldUsername: string; newUsername: string };
+```
+
+**Step 2: Add clientId to ChatMessage interface**
+
+```typescript
+interface ChatMessage {
+  id: string;
+  clientId: string;
+  username: string;
+  text: string;
+  timestamp: number;
+  context?: MessageContext;
+}
+```
+
+**Step 3: Add RENAME to CLIENT_MESSAGE_TYPE constants (server message type)**
+
+```typescript
+// Add to SERVER_MESSAGE_TYPE:
+  RENAME: "rename",
+```
+
+**Step 4: Update ClientModAction — clientId instead of username/ip**
+
+```typescript
+type ClientModAction =
+  | { type: typeof CLIENT_MESSAGE_TYPE.DELETE; data: { id: string } }
+  | { type: typeof CLIENT_MESSAGE_TYPE.FLAG; data: { id: string } }
+  | { type: typeof CLIENT_MESSAGE_TYPE.DELETE_BY_USER; data: { clientId: string } }
+  | { type: typeof CLIENT_MESSAGE_TYPE.UNBLOCK; data: { clientId: string } };
+```
+
+**Step 5: Update appendMessage — store clientId as data attribute**
+
+In the `appendMessage` function, after `root.dataset.msgId = String(msg.id);` add:
+
+```typescript
+root.dataset.clientId = msg.clientId;
+```
+
+**Step 6: Update flag callback — use clientId from message**
+
+In the flag button click handler, change the `FLAGGED` response handler to use `clientId`. The flag action itself already sends message `id` (unchanged). The change is in the `FLAGGED` response handler later.
+
+**Step 7: Update appendMessage — pass clientId in message object**
+
+In the `SERVER_MESSAGE_TYPE.MESSAGE` handler, include `clientId`:
+
+```typescript
+appendMessage({
+  id: data.id,
+  clientId: data.clientId,
+  username: data.username,
+  text: data.text,
+  timestamp: data.timestamp,
+  context: data.context,
+});
+```
+
+**Step 8: Handle rename message**
+
+Add a new handler in the message event listener:
+
+```typescript
+} else if (data.type === SERVER_MESSAGE_TYPE.RENAME) {
+  const usernameEls = messagesEl.querySelectorAll<HTMLElement>('[data-chat="username"]');
+  for (const el of usernameEls) {
+    if (el.textContent === data.oldUsername) {
+      el.textContent = data.newUsername;
+    }
+  }
+```
+
+**Step 9: Update FLAGGED handler — use clientId for delete-by-user**
+
+```typescript
+} else if (data.type === SERVER_MESSAGE_TYPE.FLAGGED) {
+  appendSystemMessage(`Banned ${data.username}.\nDelete their messages?`, [
+    {
+      label: "all",
+      action: () => wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE_BY_USER, data: { clientId: data.clientId } }),
+    },
+    { label: "this one", action: () => wsSend({ type: CLIENT_MESSAGE_TYPE.DELETE, data: { id: data.messageId } }) },
+    { label: "none", action: () => {} },
+  ]);
+```
+
+**Step 10: Update UNBLOCKED handler — show clientId**
+
+```typescript
+} else if (data.type === SERVER_MESSAGE_TYPE.UNBLOCKED) {
+  appendSystemMessage(`Unblocked user: ${data.clientId.slice(0, 8)}…`);
+```
+
+**Step 11: Update BLOCKED_LIST handler — use clientId**
+
+```typescript
+} else if (data.type === SERVER_MESSAGE_TYPE.BLOCKED_LIST) {
+  if (data.entries.length === 0) {
+    appendSystemMessage("No blocked users.");
+  } else {
+    appendSystemMessage(`Blocked users (${data.entries.length}):`);
+    for (const e of data.entries) {
+      const date = e.blockedAt > 0 ? new Date(e.blockedAt).toLocaleDateString() : "unknown date";
+      appendSystemMessage(`  ${e.username} — ${e.clientId.slice(0, 8)}… (blocked ${date})`, [
+        {
+          label: "unblock",
+          action: () => {
+            wsSend({ type: CLIENT_MESSAGE_TYPE.UNBLOCK, data: { clientId: e.clientId } });
+          },
+        },
+      ]);
+    }
+  }
+```
+
+**Step 12: Run typecheck**
+
+Run: `just app::typecheck`
+Expected: PASS
+
+**Step 13: Commit**
+
+```bash
+git add app/src/components/Chat/chat-client.ts
+git commit -m "refactor(chat): update client to use clientId for identity and handle rename"
+```
+
+---
+
+### Task 4: Update API tests
+
+**Files:**
+- Modify: `api/src/__tests__/chat-room.test.ts`
+
+**Step 1: Update openWs helper — remove ip parameter**
+
+```typescript
+async function openWs(): Promise<WebSocket> {
+  const resp = await SELF.fetch("https://fake-host/ws", {
+    headers: { Upgrade: "websocket" },
+  });
+  const ws = resp.webSocket;
+  if (!ws) throw new Error("No WebSocket returned");
+  ws.accept();
+  return ws;
+}
+```
+
+**Step 2: Update connectAndJoin — remove ip option, add clientId**
+
+```typescript
+async function connectAndJoin(
+  username: string,
+  options?: { token?: string; clientId?: string },
+): Promise<{ ws: WebSocket; msgs: ServerMessage[] }> {
+  const ws = await openWs();
+  const msgs = collect(ws);
+  await flush();
+
+  const data: Record<string, unknown> = { username, clientId: options?.clientId ?? crypto.randomUUID() };
+  if (options?.token) data.token = options.token;
+  send(ws, { type: CLIENT_MESSAGE_TYPE.JOIN, data });
+  await flush();
+  return { ws, msgs };
+}
+```
+
+**Step 3: Remove all `ip:` options from test calls**
+
+Search for `ip:` in test file and remove those options from `connectAndJoin` and `openWs` calls. Affected tests:
+- "admin can unblock" — remove `ip` options
+- "/help is not broadcast" — remove `ip` options
+- "admin /blocked" — remove `ip` option, assert `clientId` instead of `ip` on blocked entry
+- "admin can flag" — remove `ip` options, assert `clientId` instead of `ip` on flagged response
+- "non-admin flag" — remove `ip` options
+- "reserved word" tests — no `ip` to remove (already fine)
+
+**Step 4: Rename "IP blocking" describe to "Blocking"**
+
+**Step 5: Update "admin can unblock" test — use clientId**
+
+```typescript
+describe("Blocking", () => {
+  it("admin can unblock a client via unblock message", async () => {
+    const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+      token: "test-admin-secret",
+    });
+    adminMsgs.length = 0;
+
+    send(adminWs, { type: CLIENT_MESSAGE_TYPE.UNBLOCK, data: { clientId: "some-client-id" } });
+    await flush();
+
+    const unblocked = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.UNBLOCKED);
+    expect(unblocked).toMatchObject({ type: SERVER_MESSAGE_TYPE.UNBLOCKED, clientId: "some-client-id" });
+
+    adminWs.close();
+  });
+});
+```
+
+**Step 6: Update "admin /blocked" test — assert clientId on entry**
+
+Update the assertion from `e.ip === "10.0.0.77"` to checking that the entry has a `clientId` property and username matches:
+
+```typescript
+const entry = list.entries.find((e) => e.username === "troublemaker");
+expect(entry).toBeDefined();
+if (entry) {
+  expect(entry.clientId).toBeDefined();
+  expect(entry.blockedAt).toBeGreaterThan(0);
+}
+```
+
+**Step 7: Update "admin can flag" test — assert clientId instead of ip**
+
+```typescript
+const flagged = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.FLAGGED);
+expect(flagged).toMatchObject({
+  type: SERVER_MESSAGE_TYPE.FLAGGED,
+  username: "bad-user",
+  clientId: expect.any(String),
+  messageId: msgId,
+});
+```
+
+**Step 8: Update "admin can delete all messages" test — send clientId**
+
+Get the clientId from the message and use it for delete_by_user:
+
+```typescript
+it("admin can delete all messages from a client", async () => {
+  const cid = crypto.randomUUID();
+  const { ws: userWs } = await connectAndJoin("bulk-poster", { clientId: cid });
+  const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+    token: "test-admin-secret",
+  });
+
+  send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "spam 1" } });
+  send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "spam 2" } });
+  send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "spam 3" } });
+  await flush();
+
+  adminMsgs.length = 0;
+
+  send(adminWs, { type: "delete_by_user", data: { clientId: cid } });
+  await flush();
+
+  const removes = adminMsgs.filter((m) => m.type === SERVER_MESSAGE_TYPE.REMOVE);
+  expect(removes).toHaveLength(3);
+
+  userWs.close();
+  adminWs.close();
+});
+```
+
+**Step 9: Update "non-admin delete_by_user" test — send clientId**
+
+```typescript
+send(ws2, { type: "delete_by_user", data: { clientId: "some-fake-id" } });
+```
+
+**Step 10: Add new test — rename broadcasts to all clients**
+
+```typescript
+it("re-joining with new username broadcasts rename and updates history", async () => {
+  const cid = crypto.randomUUID();
+  const { ws: ws1, msgs: msgs1 } = await connectAndJoin("old-name", { clientId: cid });
+  const { ws: ws2, msgs: msgs2 } = await connectAndJoin("observer");
+
+  // Send a message as old-name
+  send(ws1, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "hello" } });
+  await flush();
+
+  msgs1.length = 0;
+  msgs2.length = 0;
+
+  // Re-join with new username, same clientId
+  send(ws1, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "new-name", clientId: cid } });
+  await flush();
+
+  // Observer should receive rename
+  const rename = msgs2.find((m) => m.type === SERVER_MESSAGE_TYPE.RENAME);
+  expect(rename).toMatchObject({
+    type: SERVER_MESSAGE_TYPE.RENAME,
+    oldUsername: "old-name",
+    newUsername: "new-name",
+  });
+
+  // New user connecting should see updated history
+  const { ws: ws3, msgs: msgs3 } = await connectAndJoin("late-joiner");
+  const history = msgs3.find((m) => m.type === SERVER_MESSAGE_TYPE.HISTORY);
+  if (history && history.type === SERVER_MESSAGE_TYPE.HISTORY) {
+    const fromRenamed = history.messages.filter((m) => m.username === "new-name");
+    expect(fromRenamed.length).toBeGreaterThanOrEqual(1);
+    const fromOld = history.messages.filter((m) => m.username === "old-name");
+    expect(fromOld).toHaveLength(0);
+  }
+
+  ws1.close();
+  ws2.close();
+  ws3.close();
+});
+```
+
+**Step 11: Add new test — flag works after user renames**
+
+```typescript
+it("flag works after user has renamed", async () => {
+  const cid = crypto.randomUUID();
+  const { ws: userWs, msgs: userMsgs } = await connectAndJoin("original", { clientId: cid });
+  const { ws: adminWs, msgs: adminMsgs } = await connectAndJoin("thalida", {
+    token: "test-admin-secret",
+  });
+
+  // Send a message, then rename
+  send(userWs, { type: CLIENT_MESSAGE_TYPE.MESSAGE, data: { text: "bad content" } });
+  await flush();
+
+  const chatMsg = adminMsgs.find((m): m is ChatMessage => m.type === SERVER_MESSAGE_TYPE.MESSAGE);
+  const msgId = chatMsg?.id;
+
+  // Rename
+  send(userWs, { type: CLIENT_MESSAGE_TYPE.JOIN, data: { username: "renamed", clientId: cid } });
+  await flush();
+
+  adminMsgs.length = 0;
+  userMsgs.length = 0;
+
+  // Flag the old message — should still work
+  send(adminWs, { type: "flag", data: { id: msgId } });
+  await flush();
+
+  const flagged = adminMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.FLAGGED);
+  expect(flagged).toBeDefined();
+
+  const blocked = userMsgs.find((m) => m.type === SERVER_MESSAGE_TYPE.BLOCKED);
+  expect(blocked).toBeDefined();
+
+  adminWs.close();
+  userWs.close();
+});
+```
+
+**Step 12: Run all API tests**
+
+Run: `just api::test`
+Expected: All tests PASS
+
+**Step 13: Commit**
+
+```bash
+git add api/src/__tests__/chat-room.test.ts
+git commit -m "test(api): update chat tests for clientId-based identity and rename"
+```
+
+---
+
+### Task 5: Run full test suite and typecheck
+
+**Files:** None (verification only)
+
+**Step 1: Run API typecheck**
+
+Run: `just api::typecheck`
+Expected: PASS
+
+**Step 2: Run app typecheck**
+
+Run: `just app::typecheck`
+Expected: PASS
+
+**Step 3: Run all tests**
+
+Run: `just test`
+Expected: All tests PASS
+
+**Step 4: Run app build**
+
+Run: `just app::build`
+Expected: Build succeeds
+
+**Step 5: Commit any remaining fixes if needed**

--- a/just/api.just
+++ b/just/api.just
@@ -57,6 +57,12 @@ test:
 typecheck:
     npm run typecheck
 
+# ─── Data ────────────────────────────────────────────────────────────
+
+[doc("Clear local Durable Object storage (messages, users, etc.)")]
+reset-local:
+    rm -rf .wrangler/state/
+
 # ─── Deploy ──────────────────────────────────────────────────────────
 
 [doc("Deploy the API Worker")]


### PR DESCRIPTION
## Summary

- **Admin command system**: Slash command registry (`/help`, `/blocked`, `/clear`) for owner-only operations
- **Moderation tools**: Admin can delete messages, flag/ban users, delete all messages by user, unblock users — with OpenAI moderation API integration for auto-flagging
- **Identity rearchitecture**: Server-authoritative usernames via `client:{clientId}` mapping — removes username from localStorage, server assigns/remembers usernames, dedicated `/rename` message type
- **Online status dots**: Per-message status dots showing which users are currently connected, synced via `onlineUsernames` in status broadcasts
- **Theme & accessibility**: Admin gold (#d4a520), own messages ice blue (#7dd3fc), other users teal — all colors pass WCAG AAA (7:1+ contrast)
- **Chat UI polish**: Full-width messages, word wrapping, spacing fixes, system notice styling, `just api::reset-local` command

## Test plan

- [x] `just api::typecheck` — passes
- [x] `just api::test` — 55 tests pass
- [x] `just app::typecheck` — passes
- [x] `just app::build` — builds successfully
- [ ] Manual: admin login/logout preserves pre-admin username
- [ ] Manual: `/clear` removes all messages, keeps users
- [ ] Manual: `/help` shows command list
- [ ] Manual: online status dots update on connect/disconnect/rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)