### PR TITLE
feat(chat): idle WebSocket disconnect after 5 min

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,3 +32,4 @@
 - [ ] audit all tests - mock [moderation] skipped: OPENAI_API_KEY not set
 - [ ] Fix top-[35px]
 - [x] Add moon and sun layers to sky component
+- [ ] Update site urls for older versions

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -156,7 +156,8 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260218.0.tgz",
       "integrity": "sha512-E28uJNJb9J9pca3RaxjXm1JxAjp8td9/cudkY+IT8rio71NlshN7NKMe2Cr/6GN+RufbSnp+N3ZKP74xgUaL0A==",
       "dev": true,
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1821,6 +1822,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -2095,6 +2097,7 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -2110,6 +2113,7 @@
       "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "magic-string": "^0.30.17",
@@ -2153,6 +2157,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2508,6 +2513,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3202,6 +3208,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3565,6 +3572,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3613,6 +3621,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -3646,6 +3655,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3744,6 +3754,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -3861,6 +3872,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -83,7 +83,8 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
       "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.7.5",
@@ -320,6 +321,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -360,6 +362,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2878,6 +2881,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3211,6 +3215,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3400,6 +3405,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.17.2.tgz",
       "integrity": "sha512-7jnMqGo53hOQNwo1N/wqeOvUp8wwW/p+DeerSjSkHNx8L/1mhy6P7rVo7EhdmF8DpKqw0tl/B5Fx1WcIzg1ysA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -4324,6 +4330,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7091,6 +7098,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7787,6 +7795,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8195,7 +8204,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.0.tgz",
       "integrity": "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -8795,6 +8805,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -9597,6 +9608,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -9660,6 +9672,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/app/src/components/Chat/__tests__/chat-idle.test.ts
+++ b/app/src/components/Chat/__tests__/chat-idle.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createIdleManager } from "@components/Chat/chat-idle";
+
+describe("createIdleManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls onIdle after timeout when tab is hidden", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleVisibilityChange(true); // hidden
+    vi.advanceTimersByTime(5000);
+
+    expect(onIdle).toHaveBeenCalledOnce();
+    expect(onActive).not.toHaveBeenCalled();
+
+    manager.destroy();
+  });
+
+  it("does not call onIdle if tab becomes visible before timeout", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleVisibilityChange(true); // hidden
+    vi.advanceTimersByTime(3000);
+    manager.handleVisibilityChange(false); // visible again
+
+    vi.advanceTimersByTime(5000);
+
+    expect(onIdle).not.toHaveBeenCalled();
+
+    manager.destroy();
+  });
+
+  it("calls onActive when tab becomes visible while idle", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleVisibilityChange(true); // hidden
+    vi.advanceTimersByTime(5000); // triggers idle
+    manager.handleVisibilityChange(false); // visible again
+
+    expect(onActive).toHaveBeenCalledOnce();
+
+    manager.destroy();
+  });
+
+  it("calls onActive when user interacts while idle", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleVisibilityChange(true); // hidden
+    vi.advanceTimersByTime(5000); // triggers idle
+    manager.handleActivity(); // user interaction
+
+    expect(onActive).toHaveBeenCalledOnce();
+
+    manager.destroy();
+  });
+
+  it("does not call onActive on interaction when not idle", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleActivity();
+
+    expect(onActive).not.toHaveBeenCalled();
+
+    manager.destroy();
+  });
+
+  it("does not start timer when tab is visible", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleVisibilityChange(false); // visible
+    vi.advanceTimersByTime(10000);
+
+    expect(onIdle).not.toHaveBeenCalled();
+
+    manager.destroy();
+  });
+
+  it("resets idle state on reconnect so the cycle can repeat", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    // First cycle: go idle, come back
+    manager.handleVisibilityChange(true);
+    vi.advanceTimersByTime(5000);
+    expect(onIdle).toHaveBeenCalledOnce();
+
+    manager.handleVisibilityChange(false); // triggers onActive
+    expect(onActive).toHaveBeenCalledOnce();
+
+    // Second cycle: go idle again
+    manager.handleVisibilityChange(true);
+    vi.advanceTimersByTime(5000);
+    expect(onIdle).toHaveBeenCalledTimes(2);
+
+    manager.destroy();
+  });
+
+  it("exposes isIdle state", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    expect(manager.isIdle).toBe(false);
+
+    manager.handleVisibilityChange(true);
+    vi.advanceTimersByTime(5000);
+    expect(manager.isIdle).toBe(true);
+
+    manager.handleVisibilityChange(false);
+    expect(manager.isIdle).toBe(false);
+
+    manager.destroy();
+  });
+});

--- a/app/src/components/Chat/chat-client.ts
+++ b/app/src/components/Chat/chat-client.ts
@@ -1,7 +1,9 @@
 import { validateUsername, setAdminUsername, LS_ADMIN_TOKEN_KEY } from "@components/Chat/chat-utils";
 import { truncateMiddle, formatMessageTime, renderNotice } from "@components/Chat/chat-render";
+import { createIdleManager } from "@components/Chat/chat-idle";
 
 const RECONNECT_DELAY_MS = 3000;
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
 const CLIENT_MESSAGE_TYPE = {
   JOIN: "join",
@@ -80,6 +82,7 @@ let adminUsername: string | null = null;
 let isOwner = false;
 let pendingRename = false;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let idleManager: ReturnType<typeof createIdleManager> | null = null;
 
 const usernameInput = document.querySelector('[data-chat="username-input"]') as HTMLInputElement;
 const usernameRow = document.querySelector('[data-chat="username-row"]') as HTMLLabelElement;
@@ -302,6 +305,7 @@ function connect(): void {
 }
 
 function scheduleReconnect(): void {
+  if (idleManager?.isIdle) return;
   if (reconnectTimer) return;
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
@@ -433,4 +437,29 @@ async function fetchConfig(): Promise<void> {
 fetchConfig().then(() => {
   loadIdentity();
   connect();
+
+  idleManager = createIdleManager({
+    timeoutMs: IDLE_TIMEOUT_MS,
+    onIdle() {
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      ws?.close();
+    },
+    onActive() {
+      connect();
+    },
+  });
+
+  document.addEventListener("visibilitychange", () => {
+    idleManager?.handleVisibilityChange(document.hidden);
+  });
+
+  const chatEl = document.querySelector('[data-chat="panel"]');
+  if (chatEl) {
+    for (const event of ["mousemove", "keydown", "touchstart"] as const) {
+      chatEl.addEventListener(event, () => idleManager?.handleActivity(), { passive: true });
+    }
+  }
 });

--- a/app/src/components/Chat/chat-idle.ts
+++ b/app/src/components/Chat/chat-idle.ts
@@ -1,0 +1,66 @@
+interface IdleManagerOptions {
+  onIdle: () => void;
+  onActive: () => void;
+  timeoutMs: number;
+}
+
+interface IdleManager {
+  isIdle: boolean;
+  handleVisibilityChange: (hidden: boolean) => void;
+  handleActivity: () => void;
+  destroy: () => void;
+}
+
+export function createIdleManager(options: IdleManagerOptions): IdleManager {
+  const { onIdle, onActive, timeoutMs } = options;
+  let idle = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearIdleTimer(): void {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function startIdleTimer(): void {
+    clearIdleTimer();
+    timer = setTimeout(() => {
+      timer = null;
+      idle = true;
+      onIdle();
+    }, timeoutMs);
+  }
+
+  function wake(): void {
+    if (idle) {
+      idle = false;
+      onActive();
+    }
+  }
+
+  const manager: IdleManager = {
+    get isIdle() {
+      return idle;
+    },
+
+    handleVisibilityChange(hidden: boolean) {
+      if (hidden) {
+        startIdleTimer();
+      } else {
+        clearIdleTimer();
+        wake();
+      }
+    },
+
+    handleActivity() {
+      wake();
+    },
+
+    destroy() {
+      clearIdleTimer();
+    },
+  };
+
+  return manager;
+}

--- a/docs/plans/2026-03-03-idle-websocket-disconnect-design.md
+++ b/docs/plans/2026-03-03-idle-websocket-disconnect-design.md
@@ -1,0 +1,57 @@
+# Idle WebSocket Disconnect Design
+
+## Problem
+
+The ChatRoom Durable Object accumulates wall-clock duration as long as any WebSocket is connected. Idle browser tabs keep connections open indefinitely, which exceeded the Cloudflare free tier limit (2,147,483,647 ms/day).
+
+## Solution
+
+Client-driven idle detection: the client tracks user activity and closes the WebSocket after 5 minutes of inactivity (tab hidden + no interaction). Reconnects instantly when the user returns.
+
+## Approach
+
+**Client-only changes** in `app/src/components/Chat/chat-client.ts`. No server or protocol changes needed — the server already handles close/reconnect correctly.
+
+### New State
+
+- `isIdle: boolean` — whether the client intentionally disconnected due to inactivity
+- `idleTimer: ReturnType<typeof setTimeout> | null` — the 5-minute countdown
+
+### Activity Signals
+
+- `document.visibilitychange` — tab hidden/visible
+- `mousemove`, `keydown`, `touchstart` on the chat container — user interaction
+
+### Idle Lifecycle
+
+```
+Tab visible, connected      -> no timer running
+Tab hidden                  -> start 5-min idle timer
+  User returns before 5m    -> cancel timer, stay connected
+  Timer expires             -> ws.close(), isIdle = true
+Tab visible / user interacts -> if isIdle, connect() immediately
+```
+
+### Changes to Reconnect Behavior
+
+- `scheduleReconnect()`: skip the automatic 3-second reconnect loop when `isIdle` is true (no point reconnecting in a hidden tab)
+- Reconnection only triggered by activity detection (visibility change or user interaction)
+- Existing reconnect-on-error/close behavior unchanged for network failures
+
+### Reconnect Experience
+
+1. Activity detected -> `connect()` called
+2. WebSocket opens -> `sendJoin()` with stored `clientId`
+3. Server responds with `joined` (same username) + `history` + `status`
+4. User sees messages restored, same username, no disruption
+
+### Constants
+
+- `IDLE_TIMEOUT_MS = 5 * 60 * 1000` (5 minutes)
+
+## What Stays the Same
+
+- No new message types or protocol changes
+- Server code untouched
+- `clientId` persistence in localStorage unchanged
+- Username reservation system unchanged

--- a/docs/plans/2026-03-03-idle-websocket-disconnect-implementation.md
+++ b/docs/plans/2026-03-03-idle-websocket-disconnect-implementation.md
@@ -1,0 +1,399 @@
+# Idle WebSocket Disconnect Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Disconnect idle chat WebSockets after 5 minutes to reduce Cloudflare Durable Object duration usage on the free tier.
+
+**Architecture:** Extract idle detection logic into a testable module (`chat-idle.ts`) that tracks tab visibility and user interaction, then integrate it into the existing `chat-client.ts` to control connect/disconnect. Client-only changes — no server modifications.
+
+**Tech Stack:** TypeScript, Vitest, browser APIs (visibilitychange, Page Visibility API)
+
+---
+
+### Task 1: Create the idle manager module with tests
+
+**Files:**
+- Create: `app/src/components/Chat/chat-idle.ts`
+- Create: `app/src/components/Chat/__tests__/chat-idle.test.ts`
+
+**Step 1: Write the failing tests**
+
+File: `app/src/components/Chat/__tests__/chat-idle.test.ts`
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createIdleManager } from "@components/Chat/chat-idle";
+
+describe("createIdleManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllTimers();
+  });
+
+  it("calls onIdle after timeout when tab is hidden", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleVisibilityChange(true); // hidden
+    vi.advanceTimersByTime(5000);
+
+    expect(onIdle).toHaveBeenCalledOnce();
+    expect(onActive).not.toHaveBeenCalled();
+
+    manager.destroy();
+  });
+
+  it("does not call onIdle if tab becomes visible before timeout", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleVisibilityChange(true); // hidden
+    vi.advanceTimersByTime(3000);
+    manager.handleVisibilityChange(false); // visible again
+
+    vi.advanceTimersByTime(5000);
+
+    expect(onIdle).not.toHaveBeenCalled();
+
+    manager.destroy();
+  });
+
+  it("calls onActive when tab becomes visible while idle", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleVisibilityChange(true); // hidden
+    vi.advanceTimersByTime(5000); // triggers idle
+    manager.handleVisibilityChange(false); // visible again
+
+    expect(onActive).toHaveBeenCalledOnce();
+
+    manager.destroy();
+  });
+
+  it("calls onActive when user interacts while idle", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleVisibilityChange(true); // hidden
+    vi.advanceTimersByTime(5000); // triggers idle
+    manager.handleActivity(); // user interaction
+
+    expect(onActive).toHaveBeenCalledOnce();
+
+    manager.destroy();
+  });
+
+  it("does not call onActive on interaction when not idle", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleActivity();
+
+    expect(onActive).not.toHaveBeenCalled();
+
+    manager.destroy();
+  });
+
+  it("does not start timer when tab is visible", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    manager.handleVisibilityChange(false); // visible
+    vi.advanceTimersByTime(10000);
+
+    expect(onIdle).not.toHaveBeenCalled();
+
+    manager.destroy();
+  });
+
+  it("resets idle state on reconnect so the cycle can repeat", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    // First cycle: go idle, come back
+    manager.handleVisibilityChange(true);
+    vi.advanceTimersByTime(5000);
+    expect(onIdle).toHaveBeenCalledOnce();
+
+    manager.handleVisibilityChange(false); // triggers onActive
+    expect(onActive).toHaveBeenCalledOnce();
+
+    // Second cycle: go idle again
+    manager.handleVisibilityChange(true);
+    vi.advanceTimersByTime(5000);
+    expect(onIdle).toHaveBeenCalledTimes(2);
+
+    manager.destroy();
+  });
+
+  it("exposes isIdle state", () => {
+    const onIdle = vi.fn();
+    const onActive = vi.fn();
+    const manager = createIdleManager({ onIdle, onActive, timeoutMs: 5000 });
+
+    expect(manager.isIdle).toBe(false);
+
+    manager.handleVisibilityChange(true);
+    vi.advanceTimersByTime(5000);
+    expect(manager.isIdle).toBe(true);
+
+    manager.handleVisibilityChange(false);
+    expect(manager.isIdle).toBe(false);
+
+    manager.destroy();
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `just app::test -- app/src/components/Chat/__tests__/chat-idle.test.ts`
+Expected: FAIL — module `chat-idle` does not exist
+
+**Step 3: Write the implementation**
+
+File: `app/src/components/Chat/chat-idle.ts`
+
+```typescript
+interface IdleManagerOptions {
+  onIdle: () => void;
+  onActive: () => void;
+  timeoutMs: number;
+}
+
+interface IdleManager {
+  isIdle: boolean;
+  handleVisibilityChange: (hidden: boolean) => void;
+  handleActivity: () => void;
+  destroy: () => void;
+}
+
+export function createIdleManager(options: IdleManagerOptions): IdleManager {
+  const { onIdle, onActive, timeoutMs } = options;
+  let idle = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearIdleTimer(): void {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function startIdleTimer(): void {
+    clearIdleTimer();
+    timer = setTimeout(() => {
+      timer = null;
+      idle = true;
+      onIdle();
+    }, timeoutMs);
+  }
+
+  function wake(): void {
+    if (idle) {
+      idle = false;
+      onActive();
+    }
+  }
+
+  const manager: IdleManager = {
+    get isIdle() {
+      return idle;
+    },
+
+    handleVisibilityChange(hidden: boolean) {
+      if (hidden) {
+        startIdleTimer();
+      } else {
+        clearIdleTimer();
+        wake();
+      }
+    },
+
+    handleActivity() {
+      wake();
+    },
+
+    destroy() {
+      clearIdleTimer();
+    },
+  };
+
+  return manager;
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `just app::test -- app/src/components/Chat/__tests__/chat-idle.test.ts`
+Expected: All 8 tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add app/src/components/Chat/chat-idle.ts app/src/components/Chat/__tests__/chat-idle.test.ts
+git commit -m "feat(chat): add idle detection manager with tests"
+```
+
+---
+
+### Task 2: Integrate idle manager into chat-client.ts
+
+**Files:**
+- Modify: `app/src/components/Chat/chat-client.ts`
+
+**Step 1: Add import and constant**
+
+At the top of `chat-client.ts`, add the import after the existing imports (line 2):
+
+```typescript
+import { createIdleManager } from "@components/Chat/chat-idle";
+```
+
+Add the timeout constant after `RECONNECT_DELAY_MS` (line 4):
+
+```typescript
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+```
+
+**Step 2: Add the idle manager variable**
+
+After the `reconnectTimer` declaration (line 82), add:
+
+```typescript
+let idleManager: ReturnType<typeof createIdleManager> | null = null;
+```
+
+**Step 3: Modify `scheduleReconnect()` to skip reconnect when idle**
+
+Change `scheduleReconnect()` (lines 304-310) from:
+
+```typescript
+function scheduleReconnect(): void {
+  if (reconnectTimer) return;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connect();
+  }, RECONNECT_DELAY_MS);
+}
+```
+
+To:
+
+```typescript
+function scheduleReconnect(): void {
+  if (idleManager?.isIdle) return;
+  if (reconnectTimer) return;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connect();
+  }, RECONNECT_DELAY_MS);
+}
+```
+
+**Step 4: Initialize idle manager and attach DOM listeners**
+
+Replace the initialization block at the bottom (lines 433-436) from:
+
+```typescript
+fetchConfig().then(() => {
+  loadIdentity();
+  connect();
+});
+```
+
+To:
+
+```typescript
+fetchConfig().then(() => {
+  loadIdentity();
+  connect();
+
+  idleManager = createIdleManager({
+    timeoutMs: IDLE_TIMEOUT_MS,
+    onIdle() {
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      ws?.close();
+    },
+    onActive() {
+      connect();
+    },
+  });
+
+  document.addEventListener("visibilitychange", () => {
+    idleManager?.handleVisibilityChange(document.hidden);
+  });
+
+  const chatEl = document.querySelector('[data-chat="panel"]');
+  if (chatEl) {
+    for (const event of ["mousemove", "keydown", "touchstart"] as const) {
+      chatEl.addEventListener(event, () => idleManager?.handleActivity(), { passive: true });
+    }
+  }
+});
+```
+
+**Step 5: Run all tests to verify nothing is broken**
+
+Run: `just app::test`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```bash
+git add app/src/components/Chat/chat-client.ts
+git commit -m "feat(chat): disconnect WebSocket after 5 min idle, reconnect on activity"
+```
+
+---
+
+### Task 3: Verify the chat panel data attribute exists
+
+**Files:**
+- Check: `app/src/components/Chat/Chat.astro`
+
+**Step 1: Verify `data-chat="panel"` exists on the chat container**
+
+Search `Chat.astro` for `data-chat="panel"`. If it doesn't exist, add it to the outermost chat container element.
+
+**Step 2: Run the full test suite**
+
+Run: `just app::test`
+Expected: All tests PASS
+
+**Step 3: Commit (only if Chat.astro was modified)**
+
+```bash
+git add app/src/components/Chat/Chat.astro
+git commit -m "fix(chat): add panel data attribute for idle detection listeners"
+```
+
+---
+
+### Task 4: Build verification
+
+**Step 1: Run the app build**
+
+Run: `just app::build`
+Expected: Build succeeds with no TypeScript errors
+
+**Step 2: Commit the design doc**
+
+```bash
+git add docs/plans/2026-03-03-idle-websocket-disconnect-design.md docs/plans/2026-03-03-idle-websocket-disconnect-implementation.md
+git commit -m "docs: add idle websocket disconnect design and implementation plan"
+```


### PR DESCRIPTION
## Summary

- Adds client-side idle detection that disconnects the chat WebSocket after 5 minutes of inactivity (tab hidden + no interaction)
- Reconnects instantly when the user returns (tab visible, mouse, keyboard, or touch activity)
- Reduces Cloudflare Durable Object wall-clock duration to stay within free tier limits

## Details

- New `chat-idle.ts` module: testable state machine with `createIdleManager` factory
- Integration in `chat-client.ts`: suppresses auto-reconnect while idle, triggers immediate reconnect on activity
- Client-only changes — no server modifications needed
- 8 new unit tests for the idle manager, all passing

## Test plan

- [ ] Verify chat connects normally on page load
- [ ] Switch to another tab, wait 5+ minutes, confirm WebSocket closes
- [ ] Return to the tab, confirm chat reconnects with same username and message history
- [ ] Verify mouse/keyboard activity on the chat panel triggers reconnect if idle
- [ ] Confirm `just app::test` passes (231 tests)
- [ ] Confirm `just app::build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)