### PR TITLE
Proxy external APIs through Worker, simplify env config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,6 @@ jobs:
         env:
           PUBLIC_R2_BASE_URL: ${{ vars.PUBLIC_R2_BASE_URL }}
           PUBLIC_CHAT_WS_URL: ${{ github.event_name == 'push' && vars.PUBLIC_CHAT_WS_URL || vars.PUBLIC_CHAT_WS_URL_PREVIEW }}
-          PUBLIC_OPENWEATHER_KEY: ${{ secrets.PUBLIC_OPENWEATHER_KEY }}
           PUBLIC_API_BASE_URL: ${{ github.event_name == 'push' && vars.PUBLIC_API_BASE_URL || vars.PUBLIC_API_BASE_URL_PREVIEW }}
           CF_PAGES_BRANCH: ${{ steps.branch.outputs.name }}
           CF_PAGES_URL: ${{ github.event_name == 'push' && 'https://thalida.com' || format('https://{0}.{1}.pages.dev', steps.branch.outputs.name, vars.CLOUDFLARE_PAGES_PROJECT) }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,7 +104,6 @@ jobs:
       - name: Build frontend
         env:
           PUBLIC_R2_BASE_URL: ${{ vars.PUBLIC_R2_BASE_URL }}
-          PUBLIC_CHAT_WS_URL: ${{ github.event_name == 'push' && vars.PUBLIC_CHAT_WS_URL || vars.PUBLIC_CHAT_WS_URL_PREVIEW }}
           PUBLIC_API_BASE_URL: ${{ github.event_name == 'push' && vars.PUBLIC_API_BASE_URL || vars.PUBLIC_API_BASE_URL_PREVIEW }}
           CF_PAGES_BRANCH: ${{ steps.branch.outputs.name }}
           CF_PAGES_URL: ${{ github.event_name == 'push' && 'https://thalida.com' || format('https://{0}.{1}.pages.dev', steps.branch.outputs.name, vars.CLOUDFLARE_PAGES_PROJECT) }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,7 +106,7 @@ jobs:
           PUBLIC_R2_BASE_URL: ${{ vars.PUBLIC_R2_BASE_URL }}
           PUBLIC_CHAT_WS_URL: ${{ github.event_name == 'push' && vars.PUBLIC_CHAT_WS_URL || vars.PUBLIC_CHAT_WS_URL_PREVIEW }}
           PUBLIC_OPENWEATHER_KEY: ${{ secrets.PUBLIC_OPENWEATHER_KEY }}
-          PUBLIC_IPREGISTRY_KEY: ${{ secrets.PUBLIC_IPREGISTRY_KEY }}
+          PUBLIC_API_BASE_URL: ${{ github.event_name == 'push' && vars.PUBLIC_API_BASE_URL || vars.PUBLIC_API_BASE_URL_PREVIEW }}
           CF_PAGES_BRANCH: ${{ steps.branch.outputs.name }}
           CF_PAGES_URL: ${{ github.event_name == 'push' && 'https://thalida.com' || format('https://{0}.{1}.pages.dev', steps.branch.outputs.name, vars.CLOUDFLARE_PAGES_PROJECT) }}
         run: just app::build-pages

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ Run `just` to see all available commands.
 
 ### Frontend (`app/.env.development`)
 
-| Variable             | Default                  | Description                    |
-| -------------------- | ------------------------ | ------------------------------ |
-| `PUBLIC_CHAT_WS_URL` | `ws://localhost:8787/ws` | WebSocket URL for the chat API |
-| `PUBLIC_R2_BASE_URL` | _(empty)_                | R2 public URL for media        |
+| Variable              | Default                 | Description                                               |
+| --------------------- | ----------------------- | --------------------------------------------------------- |
+| `PUBLIC_API_BASE_URL` | `http://localhost:8787` | Base URL of the API worker (WS URL derived automatically) |
+| `PUBLIC_R2_BASE_URL`  | _(empty)_               | R2 public URL for media                                   |
 
-`PUBLIC_CHAT_WS_URL` tunnel URL is auto-written to `.env.production`
+`PUBLIC_API_BASE_URL` tunnel URL is auto-written to `.env.production`
 by `just api::serve --env preview`. `PUBLIC_R2_BASE_URL` is empty for
 local dev (uses local files) and set in Cloudflare Pages for deploys.
 
@@ -207,13 +207,13 @@ Connect the repo to Cloudflare Pages via the dashboard:
    - **Build output directory**: `dist`
 4. Set environment variables (Settings > Environment Variables):
    - **Production**:
-     - `PUBLIC_CHAT_WS_URL` =
-       `wss://thalida-chat-api.<subdomain>.workers.dev/ws`
+     - `PUBLIC_API_BASE_URL` =
+       `https://thalida-chat-api.<subdomain>.workers.dev`
      - `PUBLIC_R2_BASE_URL` =
        `https://pub-xxxx.r2.dev` (your R2 public URL)
    - **Preview**:
-     - `PUBLIC_CHAT_WS_URL` =
-       `wss://thalida-chat-api-preview.<subdomain>.workers.dev/ws`
+     - `PUBLIC_API_BASE_URL` =
+       `https://thalida-chat-api-preview.<subdomain>.workers.dev`
      - `PUBLIC_R2_BASE_URL` =
        `https://pub-xxxx.r2.dev` (same R2 public URL)
 5. Under Build watch paths, add include path: `app/**` (avoids
@@ -234,12 +234,12 @@ variables > Actions:
 
 **Variables:**
 
-| Variable                     | Description                   |
-| ---------------------------- | ----------------------------- |
-| `PUBLIC_R2_BASE_URL`         | R2 public URL                 |
-| `CLOUDFLARE_PAGES_PROJECT`   | Cloudflare Pages project name |
-| `PUBLIC_CHAT_WS_URL`         | Production chat WebSocket URL |
-| `PUBLIC_CHAT_WS_URL_PREVIEW` | Preview chat WebSocket URL    |
+| Variable                      | Description                   |
+| ----------------------------- | ----------------------------- |
+| `PUBLIC_R2_BASE_URL`          | R2 public URL                 |
+| `CLOUDFLARE_PAGES_PROJECT`    | Cloudflare Pages project name |
+| `PUBLIC_API_BASE_URL`         | Production API base URL       |
+| `PUBLIC_API_BASE_URL_PREVIEW` | Preview API base URL          |
 
 
 ### One-time setup: Production Worker secrets

--- a/api/.dev.vars.example
+++ b/api/.dev.vars.example
@@ -13,3 +13,7 @@ OPENAI_API_KEY=
 # IP Registry API key for geolocation (used by /location endpoint).
 # Get one at https://ipregistry.co/
 IPREGISTRY_KEY=
+
+# OpenWeather API key for weather data (used by /weather endpoint).
+# Get one at https://openweathermap.org/api
+OPENWEATHER_KEY=

--- a/api/.dev.vars.example
+++ b/api/.dev.vars.example
@@ -9,3 +9,7 @@ ADMIN_SECRET=
 # Get one at https://platform.openai.com/api-keys
 # Leave blank to disable moderation locally (all messages will pass through).
 OPENAI_API_KEY=
+
+# IP Registry API key for geolocation (used by /location endpoint).
+# Get one at https://ipregistry.co/
+IPREGISTRY_KEY=

--- a/api/src/__tests__/index.test.ts
+++ b/api/src/__tests__/index.test.ts
@@ -97,6 +97,24 @@ describe("Worker routing", () => {
     });
   });
 
+  // ── Location Endpoint ──────────────────────────────────────────
+
+  describe("GET /location", () => {
+    it("returns 503 when IPREGISTRY_KEY is not configured", async () => {
+      const resp = await SELF.fetch("https://fake-host/location");
+      expect(resp.status).toBe(503);
+      const body = (await resp.json()) as { error: string };
+      expect(body.error).toBe("Location service not configured");
+    });
+
+    it("includes CORS headers", async () => {
+      const resp = await SELF.fetch("https://fake-host/location", {
+        headers: { Origin: "https://thalida.com" },
+      });
+      expect(resp.headers.get("Access-Control-Allow-Origin")).toBe("https://thalida.com");
+    });
+  });
+
   // ── Failure States ───────────────────────────────────────────────
 
   describe("failure states", () => {

--- a/api/src/__tests__/index.test.ts
+++ b/api/src/__tests__/index.test.ts
@@ -115,6 +115,24 @@ describe("Worker routing", () => {
     });
   });
 
+  // ── Weather Endpoint ────────────────────────────────────────────
+
+  describe("GET /weather", () => {
+    it("returns 503 when OPENWEATHER_KEY is not configured", async () => {
+      const resp = await SELF.fetch("https://fake-host/weather?lat=40&lon=-74");
+      expect(resp.status).toBe(503);
+      const body = (await resp.json()) as { error: string };
+      expect(body.error).toBe("Weather service not configured");
+    });
+
+    it("includes CORS headers", async () => {
+      const resp = await SELF.fetch("https://fake-host/weather?lat=40&lon=-74", {
+        headers: { Origin: "https://thalida.com" },
+      });
+      expect(resp.headers.get("Access-Control-Allow-Origin")).toBe("https://thalida.com");
+    });
+  });
+
   // ── Failure States ───────────────────────────────────────────────
 
   describe("failure states", () => {

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -63,3 +63,42 @@ export function handleConfig(env: Env, request: Request): Response {
 export function handleHealthCheck(env: Env, request: Request): Response {
   return _jsonResponse({}, 200, _corsHeaders(env, request));
 }
+
+export async function handleLocation(env: Env, request: Request): Promise<Response> {
+  const headers = _corsHeaders(env, request);
+
+  if (!env.IPREGISTRY_KEY) {
+    return _jsonResponse({ error: "Location service not configured" }, 503, headers);
+  }
+
+  const rawIp = request.headers.get("CF-Connecting-IP") ?? "";
+  const ip = /^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|::1|fd|fc)/.test(rawIp) ? "" : rawIp;
+
+  try {
+    const res = await fetch(`https://api.ipregistry.co/${ip}?key=${env.IPREGISTRY_KEY}&fields=location,time_zone`);
+    if (!res.ok) {
+      const body = await res.text();
+      console.error(`[location] IP Registry error ${res.status}: ${body}`);
+      return _jsonResponse({ error: "Upstream location service error" }, 502, headers);
+    }
+
+    const data = (await res.json()) as {
+      location?: { latitude?: number; longitude?: number; country?: { code?: string }; city?: string };
+      time_zone?: { id?: string };
+    };
+
+    return _jsonResponse(
+      {
+        lat: data.location?.latitude ?? null,
+        lng: data.location?.longitude ?? null,
+        country: data.location?.country?.code ?? null,
+        name: data.location?.city ?? null,
+        timezone: data.time_zone?.id ?? null,
+      },
+      200,
+      headers,
+    );
+  } catch {
+    return _jsonResponse({ error: "Location lookup failed" }, 502, headers);
+  }
+}

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -102,3 +102,52 @@ export async function handleLocation(env: Env, request: Request): Promise<Respon
     return _jsonResponse({ error: "Location lookup failed" }, 502, headers);
   }
 }
+
+export async function handleWeather(env: Env, request: Request): Promise<Response> {
+  const headers = _corsHeaders(env, request);
+
+  if (!env.OPENWEATHER_KEY) {
+    return _jsonResponse({ error: "Weather service not configured" }, 503, headers);
+  }
+
+  const url = new URL(request.url);
+  const lat = url.searchParams.get("lat");
+  const lon = url.searchParams.get("lon");
+  const units = url.searchParams.get("units") || "metric";
+
+  if (!lat || !lon) {
+    return _jsonResponse({ error: "lat and lon query params required" }, 400, headers);
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.openweathermap.org/data/2.5/weather?units=${encodeURIComponent(units)}&lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}&appid=${env.OPENWEATHER_KEY}`,
+    );
+    if (!res.ok) {
+      const body = await res.text();
+      console.error(`[weather] OpenWeather error ${res.status}: ${body}`);
+      return _jsonResponse({ error: "Upstream weather service error" }, 502, headers);
+    }
+
+    const data = (await res.json()) as {
+      weather?: Array<{ main?: string; description?: string; icon?: string }>;
+      main?: { temp?: number };
+      sys?: { sunrise?: number; sunset?: number };
+    };
+
+    return _jsonResponse(
+      {
+        main: data.weather?.[0]?.main ?? null,
+        description: data.weather?.[0]?.description ?? null,
+        icon: data.weather?.[0]?.icon ?? null,
+        temp: data.main?.temp ?? null,
+        sunrise: data.sys?.sunrise ?? null,
+        sunset: data.sys?.sunset ?? null,
+      },
+      200,
+      headers,
+    );
+  } catch {
+    return _jsonResponse({ error: "Weather lookup failed" }, 502, headers);
+  }
+}

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -119,6 +119,17 @@ export async function handleWeather(env: Env, request: Request): Promise<Respons
     return _jsonResponse({ error: "lat and lon query params required" }, 400, headers);
   }
 
+  const latNum = Number(lat);
+  const lonNum = Number(lon);
+  if (Number.isNaN(latNum) || Number.isNaN(lonNum) || latNum < -90 || latNum > 90 || lonNum < -180 || lonNum > 180) {
+    return _jsonResponse({ error: "lat must be -90..90 and lon must be -180..180" }, 400, headers);
+  }
+
+  const ALLOWED_UNITS = ["metric", "imperial", "standard"];
+  if (!ALLOWED_UNITS.includes(units)) {
+    return _jsonResponse({ error: `units must be one of: ${ALLOWED_UNITS.join(", ")}` }, 400, headers);
+  }
+
   try {
     const res = await fetch(
       `https://api.openweathermap.org/data/2.5/weather?units=${encodeURIComponent(units)}&lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}&appid=${env.OPENWEATHER_KEY}`,

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,7 +2,7 @@ export { ChatRoom } from "./chat-room";
 export type * from "./types";
 
 import type { Env } from "./types";
-import { handleCors, handleWebSocket, handleAuth, handleConfig, handleHealthCheck } from "./api";
+import { handleCors, handleWebSocket, handleAuth, handleConfig, handleHealthCheck, handleLocation } from "./api";
 
 export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
@@ -16,6 +16,8 @@ export default {
       return handleAuth(env, request);
     } else if (url.pathname === "/config") {
       return handleConfig(env, request);
+    } else if (url.pathname === "/location") {
+      return handleLocation(env, request);
     } else if (url.pathname === "/") {
       return handleHealthCheck(env, request);
     } else {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,7 +2,15 @@ export { ChatRoom } from "./chat-room";
 export type * from "./types";
 
 import type { Env } from "./types";
-import { handleCors, handleWebSocket, handleAuth, handleConfig, handleHealthCheck, handleLocation } from "./api";
+import {
+  handleCors,
+  handleWebSocket,
+  handleAuth,
+  handleConfig,
+  handleHealthCheck,
+  handleLocation,
+  handleWeather,
+} from "./api";
 
 export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
@@ -18,6 +26,8 @@ export default {
       return handleConfig(env, request);
     } else if (url.pathname === "/location") {
       return handleLocation(env, request);
+    } else if (url.pathname === "/weather") {
+      return handleWeather(env, request);
     } else if (url.pathname === "/") {
       return handleHealthCheck(env, request);
     } else {

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -213,6 +213,7 @@ export interface Env {
   ALLOWED_ORIGIN: string;
   OPENAI_API_KEY?: string;
   IPREGISTRY_KEY?: string;
+  OPENWEATHER_KEY?: string;
 }
 
 export interface AuthRequest {

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -212,6 +212,7 @@ export interface Env {
   ADMIN_SECRET: string;
   ALLOWED_ORIGIN: string;
   OPENAI_API_KEY?: string;
+  IPREGISTRY_KEY?: string;
 }
 
 export interface AuthRequest {

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineWorkersConfig({
           bindings: {
             ADMIN_SECRET: "test-admin-secret",
             OPENAI_API_KEY: "",
+            IPREGISTRY_KEY: "",
             ALLOWED_ORIGIN: "https://thalida.com",
           },
         },

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineWorkersConfig({
             ADMIN_SECRET: "test-admin-secret",
             OPENAI_API_KEY: "",
             IPREGISTRY_KEY: "",
+            OPENWEATHER_KEY: "",
             ALLOWED_ORIGIN: "https://thalida.com",
           },
         },

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -16,6 +16,7 @@ ALLOWED_ORIGIN = "https://thalida.com"
 
 # Set ADMIN_SECRET via `wrangler secret put ADMIN_SECRET`
 # Set OPENAI_API_KEY via `wrangler secret put OPENAI_API_KEY`
+# Set IPREGISTRY_KEY via `wrangler secret put IPREGISTRY_KEY`
 
 # ─── Preview environment (deployed via GitHub Actions on PRs) ─────────
 [env.preview]
@@ -36,3 +37,4 @@ new_sqlite_classes = ["ChatRoom"]
 # Set preview secrets once:
 #   wrangler secret put ADMIN_SECRET --env preview
 #   wrangler secret put OPENAI_API_KEY --env preview
+#   wrangler secret put IPREGISTRY_KEY --env preview

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -17,6 +17,7 @@ ALLOWED_ORIGIN = "https://thalida.com"
 # Set ADMIN_SECRET via `wrangler secret put ADMIN_SECRET`
 # Set OPENAI_API_KEY via `wrangler secret put OPENAI_API_KEY`
 # Set IPREGISTRY_KEY via `wrangler secret put IPREGISTRY_KEY`
+# Set OPENWEATHER_KEY via `wrangler secret put OPENWEATHER_KEY`
 
 # ─── Preview environment (deployed via GitHub Actions on PRs) ─────────
 [env.preview]
@@ -38,3 +39,4 @@ new_sqlite_classes = ["ChatRoom"]
 #   wrangler secret put ADMIN_SECRET --env preview
 #   wrangler secret put OPENAI_API_KEY --env preview
 #   wrangler secret put IPREGISTRY_KEY --env preview
+#   wrangler secret put OPENWEATHER_KEY --env preview

--- a/app/.env.example
+++ b/app/.env.example
@@ -2,15 +2,10 @@
 # Astro loads .env.development for `astro dev` and .env.production for `astro build`.
 # PUBLIC_ prefix is required for Astro to expose vars to the client.
 
-# WebSocket URL for the chat API.
-# .env.development:  ws://localhost:8787/ws
-# .env.production:   auto-written by `just api::serve --env preview` (tunnel URL)
-# Cloudflare Pages:  wss://api.thalida.com/ws (set in dashboard)
-PUBLIC_CHAT_WS_URL=ws://localhost:8787/ws
-
-# Base URL of the API worker (for geolocation, etc.).
+# Base URL of the API worker.
 # Local dev: http://localhost:8787
 # Production: https://api.thalida.com (set in Cloudflare Pages dashboard)
+# WebSocket URL is derived automatically (http→ws, +/ws).
 PUBLIC_API_BASE_URL=http://localhost:8787
 
 # Base URL for media files hosted on Cloudflare R2.

--- a/app/.env.example
+++ b/app/.env.example
@@ -8,10 +8,6 @@
 # Cloudflare Pages:  wss://api.thalida.com/ws (set in dashboard)
 PUBLIC_CHAT_WS_URL=ws://localhost:8787/ws
 
-# OpenWeather API key for the live window weather display.
-# Get one at https://openweathermap.org/api
-PUBLIC_OPENWEATHER_KEY=
-
 # Base URL of the API worker (for geolocation, etc.).
 # Local dev: http://localhost:8787
 # Production: https://api.thalida.com (set in Cloudflare Pages dashboard)

--- a/app/.env.example
+++ b/app/.env.example
@@ -12,9 +12,10 @@ PUBLIC_CHAT_WS_URL=ws://localhost:8787/ws
 # Get one at https://openweathermap.org/api
 PUBLIC_OPENWEATHER_KEY=
 
-# IP Registry API key for location detection (used by live window).
-# Get one at https://ipregistry.co/
-PUBLIC_IPREGISTRY_KEY=
+# Base URL of the API worker (for geolocation, etc.).
+# Local dev: http://localhost:8787
+# Production: https://api.thalida.com (set in Cloudflare Pages dashboard)
+PUBLIC_API_BASE_URL=http://localhost:8787
 
 # Base URL for media files hosted on Cloudflare R2.
 # Leave empty for local dev (images served locally with Astro optimization).

--- a/app/src/components/Chat/Chat.astro
+++ b/app/src/components/Chat/Chat.astro
@@ -1,5 +1,6 @@
 ---
-const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
+const apiBaseUrl = import.meta.env.PUBLIC_API_BASE_URL || "http://localhost:8787";
+const wsUrl = apiBaseUrl.replace(/^http(s?):/, "ws$1:") + "/ws";
 ---
 
 <aside

--- a/app/src/content.config.ts
+++ b/app/src/content.config.ts
@@ -68,7 +68,11 @@ async function combineYamlFiles({ filename, pattern, base }: { filename: string;
     }
   }
 
-  await fs.writeFile(outputPath, stringifyYaml(allEntries));
+  const newContent = stringifyYaml(allEntries);
+  const existing = await fs.readFile(outputPath, "utf-8").catch(() => "");
+  if (newContent !== existing) {
+    await fs.writeFile(outputPath, newContent);
+  }
 
   return file(outputPath);
 }

--- a/app/src/pages/index.astro
+++ b/app/src/pages/index.astro
@@ -5,7 +5,6 @@ import { COLLECTION_NAMES, collectionMeta } from "../content.config";
 import Card from "@components/Card/Card.astro";
 import SectionHeader from "@components/SectionHeader/SectionHeader.astro";
 
-const openweatherKey = import.meta.env.PUBLIC_OPENWEATHER_KEY || "";
 const apiBaseUrl = import.meta.env.PUBLIC_API_BASE_URL || "";
 
 const navData = await getNavData();
@@ -22,7 +21,7 @@ const siteAge = new Date().getFullYear() - 2007;
 <BaseLayout activePage="">
   {/* ── Hero ── */}
   <section class="flex flex-col items-center text-center gap-8" aria-label="Introduction">
-    <live-window openweather-key={openweatherKey} api-url={apiBaseUrl} theme="dark" bg-color="#030a12"></live-window>
+    <live-window api-url={apiBaseUrl} theme="dark" bg-color="#030a12"></live-window>
     <div class="max-w-xl">
       <h1 class="m-0 font-display font-bold text-neon text-display-lg tracking-tighter leading-none">
         <span data-home="greeting">Hey</span>, I'm&nbsp;Thalida

--- a/app/src/pages/index.astro
+++ b/app/src/pages/index.astro
@@ -6,7 +6,7 @@ import Card from "@components/Card/Card.astro";
 import SectionHeader from "@components/SectionHeader/SectionHeader.astro";
 
 const openweatherKey = import.meta.env.PUBLIC_OPENWEATHER_KEY || "";
-const ipregistryKey = import.meta.env.PUBLIC_IPREGISTRY_KEY || "";
+const apiBaseUrl = import.meta.env.PUBLIC_API_BASE_URL || "";
 
 const navData = await getNavData();
 
@@ -22,8 +22,7 @@ const siteAge = new Date().getFullYear() - 2007;
 <BaseLayout activePage="">
   {/* ── Hero ── */}
   <section class="flex flex-col items-center text-center gap-8" aria-label="Introduction">
-    <live-window openweather-key={openweatherKey} ipregistry-key={ipregistryKey} theme="dark" bg-color="#030a12"
-    ></live-window>
+    <live-window openweather-key={openweatherKey} api-url={apiBaseUrl} theme="dark" bg-color="#030a12"></live-window>
     <div class="max-w-xl">
       <h1 class="m-0 font-display font-bold text-neon text-display-lg tracking-tighter leading-none">
         <span data-home="greeting">Hey</span>, I'm&nbsp;Thalida

--- a/app/src/pages/live-window-test.astro
+++ b/app/src/pages/live-window-test.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "@layouts/BaseLayout/BaseLayout.astro";
 
-const openweatherKey = import.meta.env.PUBLIC_OPENWEATHER_KEY || "";
+const apiBaseUrl = import.meta.env.PUBLIC_API_BASE_URL || "";
 
 const cities = [
   { name: "New York", country: "US", lat: 40.7128, lng: -74.006, tz: "America/New_York", unit: "F" },
@@ -26,7 +26,7 @@ const cities = [
       cities.map((city) => (
         <div class="flex flex-col items-center">
           <live-window
-            openweather-key={openweatherKey}
+            api-url={apiBaseUrl}
             latitude={String(city.lat)}
             longitude={String(city.lng)}
             timezone={city.tz}

--- a/app/src/pages/login.astro
+++ b/app/src/pages/login.astro
@@ -1,9 +1,8 @@
 ---
 import BaseLayout from "@layouts/BaseLayout/BaseLayout.astro";
 
-const wsUrl = import.meta.env.PUBLIC_CHAT_WS_URL || "ws://localhost:8787/ws";
+const apiBase = import.meta.env.PUBLIC_API_BASE_URL || "http://localhost:8787";
 const LS_ADMIN_TOKEN_KEY = "admin_token";
-const apiBase = wsUrl.replace(/^ws(s?):/, "http$1:").replace(/\/ws$/, "");
 ---
 
 <BaseLayout title="login · thalida" noindex>

--- a/app/src/scripts/live-window/LiveWindow.ts
+++ b/app/src/scripts/live-window/LiveWindow.ts
@@ -14,7 +14,7 @@ import STYLES_URL from "./live-window.css?url";
 class LiveWindowElement extends HTMLElement {
   static observedAttributes = [
     "openweather-key",
-    "ipregistry-key",
+    "api-url",
     "time-format",
     "hide-clock",
     "hide-weather-text",
@@ -93,7 +93,7 @@ class LiveWindowElement extends HTMLElement {
       this.doFetchWeather();
       return;
     }
-    if (this.getAttribute("openweather-key") && this.getAttribute("ipregistry-key") && !this.weatherInterval) {
+    if (this.getAttribute("openweather-key") && this.getAttribute("api-url") && !this.weatherInterval) {
       this.startWeatherPolling();
     }
   }
@@ -197,7 +197,7 @@ class LiveWindowElement extends HTMLElement {
 
     if (
       (hasExplicitCoords && this.getAttribute("openweather-key")) ||
-      (this.getAttribute("openweather-key") && this.getAttribute("ipregistry-key"))
+      (this.getAttribute("openweather-key") && this.getAttribute("api-url"))
     ) {
       this.startWeatherPolling();
     }
@@ -255,15 +255,15 @@ class LiveWindowElement extends HTMLElement {
         },
       };
     } else {
-      const ipKey = this.getAttribute("ipregistry-key");
-      if (!ipKey) return;
+      const apiUrl = this.getAttribute("api-url");
+      if (!apiUrl) return;
 
       if (!shouldFetchWeather(this.state.store, this.state.attrs.resolvedUnits)) {
         this.updateAll();
         return;
       }
 
-      this.state.store = await fetchLocation(ipKey, this.state.store);
+      this.state.store = await fetchLocation(apiUrl, this.state.store);
       saveState(this.state);
     }
 

--- a/app/src/scripts/live-window/LiveWindow.ts
+++ b/app/src/scripts/live-window/LiveWindow.ts
@@ -13,7 +13,6 @@ import STYLES_URL from "./live-window.css?url";
 
 class LiveWindowElement extends HTMLElement {
   static observedAttributes = [
-    "openweather-key",
     "api-url",
     "time-format",
     "hide-clock",
@@ -93,7 +92,7 @@ class LiveWindowElement extends HTMLElement {
       this.doFetchWeather();
       return;
     }
-    if (this.getAttribute("openweather-key") && this.getAttribute("api-url") && !this.weatherInterval) {
+    if (this.getAttribute("api-url") && !this.weatherInterval) {
       this.startWeatherPolling();
     }
   }
@@ -193,12 +192,7 @@ class LiveWindowElement extends HTMLElement {
     this.clockInterval = window.setInterval(() => this.updateClock(), 1000);
     this.skyInterval = window.setInterval(() => this.updateAll(), 15 * 60 * 1000);
 
-    const hasExplicitCoords = this.getAttribute("latitude") != null && this.getAttribute("longitude") != null;
-
-    if (
-      (hasExplicitCoords && this.getAttribute("openweather-key")) ||
-      (this.getAttribute("openweather-key") && this.getAttribute("api-url"))
-    ) {
+    if (this.getAttribute("api-url")) {
       this.startWeatherPolling();
     }
   }
@@ -235,8 +229,8 @@ class LiveWindowElement extends HTMLElement {
   // -- API --------------------------------------------------------------------
 
   private async doFetchWeather(): Promise<void> {
-    const owKey = this.getAttribute("openweather-key");
-    if (!owKey) return;
+    const apiUrl = this.getAttribute("api-url");
+    if (!apiUrl) return;
 
     const explicitLat = this.getAttribute("latitude");
     const explicitLng = this.getAttribute("longitude");
@@ -255,9 +249,6 @@ class LiveWindowElement extends HTMLElement {
         },
       };
     } else {
-      const apiUrl = this.getAttribute("api-url");
-      if (!apiUrl) return;
-
       if (!shouldFetchWeather(this.state.store, this.state.attrs.resolvedUnits)) {
         this.updateAll();
         return;
@@ -275,7 +266,7 @@ class LiveWindowElement extends HTMLElement {
       return;
     }
 
-    const result = await fetchWeather(owKey, this.state.store, units);
+    const result = await fetchWeather(apiUrl, this.state.store, units);
     this.state.store = result.state;
 
     if (!hasExplicitCoords) {

--- a/app/src/scripts/live-window/README.md
+++ b/app/src/scripts/live-window/README.md
@@ -14,10 +14,10 @@ Include the component script and add the element to your HTML:
 <!-- or the built JS file -->
 <script src="live-window.js"></script>
 
-<live-window openweather-key="YOUR_OPENWEATHER_KEY" ipregistry-key="YOUR_IPREGISTRY_KEY"></live-window>
+<live-window openweather-key="YOUR_OPENWEATHER_KEY" api-url="https://your-api.example.com"></live-window>
 ```
 
-Both API keys are optional. Without them the component still renders a
+Both attributes are optional. Without them the component still renders a
 time-based sky gradient and clock — it just won't show real weather data.
 
 
@@ -26,7 +26,7 @@ time-based sky gradient and clock — it just won't show real weather data.
 | Attribute           | Values                          | Default    | Description                            |
 | ------------------- | ------------------------------- | ---------- | -------------------------------------- |
 | `openweather-key`   | API key string                  | _(none)_   | [OpenWeather][ow] API key for weather  |
-| `ipregistry-key`    | API key string                  | _(none)_   | [IP Registry][ipr] API key for geoloc  |
+| `api-url`           | URL string                      | _(none)_   | Base URL for the geolocation API proxy |
 | `time-format`       | `"12"` / `"24"`                 | `"24"`     | Clock display format (12h shows AM/PM) |
 | `temp-unit`         | `"F"` / `"C"` / `"auto"`        | `"auto"`   | Temp unit; `"auto"` uses user country  |
 | `hide-clock`        | boolean attribute               | _(absent)_ | Hides the clock when present           |
@@ -34,7 +34,6 @@ time-based sky gradient and clock — it just won't show real weather data.
 | `theme`             | `"light"` / `"dark"` / `"auto"` | `"auto"`   | Color theme; `"auto"` follows OS pref  |
 
 [ow]: https://openweathermap.org/api
-[ipr]: https://ipregistry.co/
 
 All attributes are reactive — changing them at runtime immediately
 updates the component.
@@ -93,10 +92,10 @@ Adding a new layer (e.g. stars, moon, sun):
 
 ### Weather Effects
 
-When an OpenWeather API key and IP Registry key are both provided:
+When an OpenWeather API key and API URL are both provided:
 
-1. **Geolocation** — IP Registry determines the user's lat/lng and
-   country code.
+1. **Geolocation** — The API proxy (`/location`) determines the user's
+   lat/lng and country code.
 2. **Weather fetch** — OpenWeather returns current conditions,
    temperature, sunrise, and sunset.
 3. **Visual effects** — The weather icon code maps to CSS-animated
@@ -110,7 +109,7 @@ When an OpenWeather API key and IP Registry key are both provided:
 
 The `temp-unit` attribute controls which units are sent to the
 OpenWeather API (`units=metric` or `units=imperial`). In `"auto"`
-mode, the country code from IP Registry is checked against a list of
+mode, the country code from the location API is checked against a list of
 imperial countries (US, Liberia, Myanmar). The resolved unit is also
 cached — if the unit changes (e.g. user switches from auto to
 explicit), stale cached data is invalidated and a fresh fetch is made.
@@ -178,7 +177,7 @@ the host page.
 | `types.ts`           | Shared interfaces: RGB, SkyGradient, PhaseInfo, etc. |
 | `color.ts`           | WCAG contrast, luminance, readable color (pure fns)  |
 | `state.ts`           | localStorage persistence, cache versioning           |
-| `api.ts`             | IP geolocation + OpenWeather fetch + rate limiting   |
+| `api.ts`             | Geolocation proxy + OpenWeather fetch + rate limiting|
 | `clock.ts`           | Clock rendering + time format logic                  |
 | `blinds.ts`          | Blinds animation + rendering                         |
 | `phase-info.ts`      | PhaseInfo builder + sun position calculation         |
@@ -189,7 +188,7 @@ the host page.
 ## Example
 
 ```html
-<live-window openweather-key="abc123" ipregistry-key="xyz789" time-format="12" temp-unit="auto"></live-window>
+<live-window openweather-key="abc123" api-url="https://api.example.com" time-format="12" temp-unit="auto"></live-window>
 
 <style>
   live-window {

--- a/app/src/scripts/live-window/README.md
+++ b/app/src/scripts/live-window/README.md
@@ -14,26 +14,23 @@ Include the component script and add the element to your HTML:
 <!-- or the built JS file -->
 <script src="live-window.js"></script>
 
-<live-window openweather-key="YOUR_OPENWEATHER_KEY" api-url="https://your-api.example.com"></live-window>
+<live-window api-url="https://your-api.example.com"></live-window>
 ```
 
-Both attributes are optional. Without them the component still renders a
+The `api-url` attribute is optional. Without it the component still renders a
 time-based sky gradient and clock — it just won't show real weather data.
 
 
 ## Attributes
 
-| Attribute           | Values                          | Default    | Description                            |
-| ------------------- | ------------------------------- | ---------- | -------------------------------------- |
-| `openweather-key`   | API key string                  | _(none)_   | [OpenWeather][ow] API key for weather  |
-| `api-url`           | URL string                      | _(none)_   | Base URL for the geolocation API proxy |
-| `time-format`       | `"12"` / `"24"`                 | `"24"`     | Clock display format (12h shows AM/PM) |
-| `temp-unit`         | `"F"` / `"C"` / `"auto"`        | `"auto"`   | Temp unit; `"auto"` uses user country  |
-| `hide-clock`        | boolean attribute               | _(absent)_ | Hides the clock when present           |
-| `hide-weather-text` | boolean attribute               | _(absent)_ | Hides the weather text when present    |
-| `theme`             | `"light"` / `"dark"` / `"auto"` | `"auto"`   | Color theme; `"auto"` follows OS pref  |
-
-[ow]: https://openweathermap.org/api
+| Attribute | Values | Default | Description |
+| --- | --- | --- | --- |
+| `api-url` | URL string | _(none)_ | API Worker base URL (geolocation + weather) |
+| `time-format` | `"12"` / `"24"` | `"24"` | Clock display format (12h shows AM/PM) |
+| `temp-unit` | `"F"` / `"C"` / `"auto"` | `"auto"` | Temp unit; `"auto"` uses user country |
+| `hide-clock` | boolean attribute | _(absent)_ | Hides the clock when present |
+| `hide-weather-text` | boolean attribute | _(absent)_ | Hides the weather text when present |
+| `theme` | `"light"` / `"dark"` / `"auto"` | `"auto"` | Color theme; `"auto"` follows OS pref |
 
 All attributes are reactive — changing them at runtime immediately
 updates the component.
@@ -92,12 +89,12 @@ Adding a new layer (e.g. stars, moon, sun):
 
 ### Weather Effects
 
-When an OpenWeather API key and API URL are both provided:
+When an API URL is provided:
 
-1. **Geolocation** — The API proxy (`/location`) determines the user's
-   lat/lng and country code.
-2. **Weather fetch** — OpenWeather returns current conditions,
-   temperature, sunrise, and sunset.
+1. **Geolocation** — The Worker's `/location` endpoint determines the
+   user's lat/lng and country code.
+2. **Weather fetch** — The Worker's `/weather` endpoint returns current
+   conditions, temperature, sunrise, and sunset.
 3. **Visual effects** — The weather icon code maps to CSS-animated
    overlays: clouds (sm/md/lg), rain droplets, lightning flashes,
    snow, and mist.
@@ -108,7 +105,7 @@ When an OpenWeather API key and API URL are both provided:
 ### Temperature Units
 
 The `temp-unit` attribute controls which units are sent to the
-OpenWeather API (`units=metric` or `units=imperial`). In `"auto"`
+weather API (`units=metric` or `units=imperial`). In `"auto"`
 mode, the country code from the location API is checked against a list of
 imperial countries (US, Liberia, Myanmar). The resolved unit is also
 cached — if the unit changes (e.g. user switches from auto to
@@ -177,7 +174,7 @@ the host page.
 | `types.ts`           | Shared interfaces: RGB, SkyGradient, PhaseInfo, etc. |
 | `color.ts`           | WCAG contrast, luminance, readable color (pure fns)  |
 | `state.ts`           | localStorage persistence, cache versioning           |
-| `api.ts`             | Geolocation proxy + OpenWeather fetch + rate limiting|
+| `api.ts`             | Location + weather fetch via Worker + rate limiting  |
 | `clock.ts`           | Clock rendering + time format logic                  |
 | `blinds.ts`          | Blinds animation + rendering                         |
 | `phase-info.ts`      | PhaseInfo builder + sun position calculation         |
@@ -188,7 +185,7 @@ the host page.
 ## Example
 
 ```html
-<live-window openweather-key="abc123" api-url="https://api.example.com" time-format="12" temp-unit="auto"></live-window>
+<live-window api-url="https://api.example.com" time-format="12" temp-unit="auto"></live-window>
 
 <style>
   live-window {

--- a/app/src/scripts/live-window/api.ts
+++ b/app/src/scripts/live-window/api.ts
@@ -72,7 +72,7 @@ export async function fetchLocation(apiUrl: string, state: StoreState): Promise<
 }
 
 export async function fetchWeather(
-  owKey: string,
+  apiUrl: string,
   state: StoreState,
   units: string,
 ): Promise<{ state: StoreState; changed: boolean }> {
@@ -80,18 +80,16 @@ export async function fetchWeather(
   if (lat == null || lng == null) return { state, changed: false };
 
   try {
-    const res = await fetch(
-      `https://api.openweathermap.org/data/2.5/weather?units=${units}&lat=${lat}&lon=${lng}&appid=${owKey}`,
-    );
+    const res = await fetch(`${apiUrl}/weather?units=${units}&lat=${lat}&lon=${lng}`);
     if (!res.ok) return { state, changed: false };
     const data = await res.json();
 
     const newState: StoreState = {
       ...state,
       weather: {
-        current: { ...data.weather[0], temp: data.main.temp },
-        sunrise: data.sys.sunrise * 1000,
-        sunset: data.sys.sunset * 1000,
+        current: { main: data.main, description: data.description, icon: data.icon, temp: data.temp },
+        sunrise: data.sunrise * 1000,
+        sunset: data.sunset * 1000,
         units,
         lastFetched: Date.now(),
       },

--- a/app/src/scripts/live-window/api.ts
+++ b/app/src/scripts/live-window/api.ts
@@ -88,10 +88,6 @@ export async function fetchWeather(
 
     const newState: StoreState = {
       ...state,
-      location: {
-        ...state.location,
-        name: data.name ?? state.location.name,
-      },
       weather: {
         current: { ...data.weather[0], temp: data.main.temp },
         sunrise: data.sys.sunrise * 1000,

--- a/app/src/scripts/live-window/api.ts
+++ b/app/src/scripts/live-window/api.ts
@@ -45,24 +45,24 @@ export function shouldFetchWeather(state: StoreState, units: string): boolean {
 // Fetch functions (return new state instead of mutating)
 // ---------------------------------------------------------------------------
 
-export async function fetchLocation(key: string, state: StoreState): Promise<StoreState> {
+export async function fetchLocation(apiUrl: string, state: StoreState): Promise<StoreState> {
   if (!shouldFetchLocation(state) && state.location.lat != null) {
     return state;
   }
 
   try {
-    const res = await fetch(`https://api.ipregistry.co/?key=${key}`);
+    const res = await fetch(`${apiUrl}/location`);
     if (!res.ok) return state;
     const data = await res.json();
 
     return {
       ...state,
       location: {
-        lat: data.location.latitude,
-        lng: data.location.longitude,
-        country: data.location.country?.code ?? null,
-        name: data.location.city ?? null,
-        timezone: data.time_zone?.id ?? null,
+        lat: data.lat,
+        lng: data.lng,
+        country: data.country ?? null,
+        name: data.name ?? null,
+        timezone: data.timezone ?? null,
         lastFetched: Date.now(),
       },
     };

--- a/app/src/scripts/live-window/state.ts
+++ b/app/src/scripts/live-window/state.ts
@@ -1,7 +1,7 @@
 import type { StoreState, LiveWindowState } from "./types";
 import { buildPhaseInfo } from "./utils/phase";
 
-export const CACHE_VERSION = 4;
+export const CACHE_VERSION = 5;
 const STORAGE_KEY = "liveWindowStore";
 
 export const DEFAULT_STORE: StoreState = {

--- a/app/src/scripts/live-window/state.ts
+++ b/app/src/scripts/live-window/state.ts
@@ -1,7 +1,7 @@
 import type { StoreState, LiveWindowState } from "./types";
 import { buildPhaseInfo } from "./utils/phase";
 
-export const CACHE_VERSION = 3;
+export const CACHE_VERSION = 4;
 const STORAGE_KEY = "liveWindowStore";
 
 export const DEFAULT_STORE: StoreState = {

--- a/docs/plans/2026-03-04-weather-api-proxy-design.md
+++ b/docs/plans/2026-03-04-weather-api-proxy-design.md
@@ -1,0 +1,38 @@
+# Design: Proxy OpenWeather API through Cloudflare Worker
+
+## Problem
+
+The OpenWeather API key is exposed client-side via `PUBLIC_OPENWEATHER_KEY`. Move the call behind the Cloudflare Worker, matching the pattern used for IP Registry geolocation.
+
+## Design
+
+### API (Cloudflare Worker)
+
+New endpoint: `GET /weather?lat={lat}&lon={lon}&units={units}`
+
+- `handleWeather()` in `api.ts` validates query params, calls `https://api.openweathermap.org/data/2.5/weather` with `env.OPENWEATHER_KEY`
+- Returns normalized response:
+  ```json
+  {
+    "main": "Clouds",
+    "description": "overcast clouds",
+    "icon": "04d",
+    "temp": 72,
+    "sunrise": 1709553600,
+    "sunset": 1709594400
+  }
+  ```
+- Route added in `index.ts` following existing pattern
+- New secret `OPENWEATHER_KEY` added to `Env` type and `.dev.vars.example`
+
+### App (Frontend)
+
+- `fetchWeather()` in `api.ts` calls `${apiUrl}/weather?lat=...&lon=...&units=...` instead of OpenWeather directly
+- Remove `PUBLIC_OPENWEATHER_KEY` from `.env.example` and all references
+- Remove `owKey` parameter threading through `LiveWindow.ts` → `fetchWeather()`
+
+### Unchanged
+
+- Rate limiting (client-side, 30-min interval)
+- Weather data consumers (WeatherLayer, InfoPanel)
+- CORS config

--- a/docs/plans/2026-03-04-weather-api-proxy-implementation.md
+++ b/docs/plans/2026-03-04-weather-api-proxy-implementation.md
@@ -1,0 +1,406 @@
+# Weather API Proxy Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move the OpenWeather API call from the client-side app to the Cloudflare Worker backend, removing the exposed API key.
+
+**Architecture:** Add a `/weather` endpoint to the existing Cloudflare Worker that proxies requests to OpenWeather. The frontend sends lat/lon/units as query params; the Worker attaches the secret API key and forwards to OpenWeather, returning a normalized response.
+
+**Tech Stack:** Cloudflare Workers (TypeScript), Astro frontend
+
+---
+
+### Task 1: Add `OPENWEATHER_KEY` to Worker types and config
+
+**Files:**
+- Modify: `api/src/types.ts:210-216` (Env interface)
+- Modify: `api/.dev.vars.example`
+
+**Step 1: Add `OPENWEATHER_KEY` to the `Env` interface**
+
+In `api/src/types.ts`, add `OPENWEATHER_KEY?: string;` to the `Env` interface:
+
+```typescript
+export interface Env {
+  CHAT_ROOM: DurableObjectNamespace;
+  ADMIN_SECRET: string;
+  ALLOWED_ORIGIN: string;
+  OPENAI_API_KEY?: string;
+  IPREGISTRY_KEY?: string;
+  OPENWEATHER_KEY?: string;
+}
+```
+
+**Step 2: Add `OPENWEATHER_KEY` to `.dev.vars.example`**
+
+Append to `api/.dev.vars.example`:
+
+```
+# OpenWeather API key for weather data (used by /weather endpoint).
+# Get one at https://openweathermap.org/api
+OPENWEATHER_KEY=
+```
+
+**Step 3: Commit**
+
+```bash
+git add api/src/types.ts api/.dev.vars.example
+git commit -m "feat(api): add OPENWEATHER_KEY to Worker env"
+```
+
+---
+
+### Task 2: Add `handleWeather()` handler and route
+
+**Files:**
+- Modify: `api/src/api.ts` (add handler after `handleLocation`)
+- Modify: `api/src/index.ts` (add route)
+
+**Step 1: Add `handleWeather` to `api/src/api.ts`**
+
+Add this function after `handleLocation`:
+
+```typescript
+export async function handleWeather(env: Env, request: Request): Promise<Response> {
+  const headers = _corsHeaders(env, request);
+
+  if (!env.OPENWEATHER_KEY) {
+    return _jsonResponse({ error: "Weather service not configured" }, 503, headers);
+  }
+
+  const url = new URL(request.url);
+  const lat = url.searchParams.get("lat");
+  const lon = url.searchParams.get("lon");
+  const units = url.searchParams.get("units") || "metric";
+
+  if (!lat || !lon) {
+    return _jsonResponse({ error: "lat and lon query params required" }, 400, headers);
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.openweathermap.org/data/2.5/weather?units=${encodeURIComponent(units)}&lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}&appid=${env.OPENWEATHER_KEY}`,
+    );
+    if (!res.ok) {
+      const body = await res.text();
+      console.error(`[weather] OpenWeather error ${res.status}: ${body}`);
+      return _jsonResponse({ error: "Upstream weather service error" }, 502, headers);
+    }
+
+    const data = (await res.json()) as {
+      weather?: Array<{ main?: string; description?: string; icon?: string }>;
+      main?: { temp?: number };
+      sys?: { sunrise?: number; sunset?: number };
+    };
+
+    return _jsonResponse(
+      {
+        main: data.weather?.[0]?.main ?? null,
+        description: data.weather?.[0]?.description ?? null,
+        icon: data.weather?.[0]?.icon ?? null,
+        temp: data.main?.temp ?? null,
+        sunrise: data.sys?.sunrise ?? null,
+        sunset: data.sys?.sunset ?? null,
+      },
+      200,
+      headers,
+    );
+  } catch {
+    return _jsonResponse({ error: "Weather lookup failed" }, 502, headers);
+  }
+}
+```
+
+**Step 2: Add route in `api/src/index.ts`**
+
+Add import of `handleWeather` and add the route before the health check:
+
+```typescript
+import { handleCors, handleWebSocket, handleAuth, handleConfig, handleHealthCheck, handleLocation, handleWeather } from "./api";
+```
+
+Add this clause after the `/location` route:
+
+```typescript
+    } else if (url.pathname === "/weather") {
+      return handleWeather(env, request);
+```
+
+**Step 3: Run type check**
+
+Run: `just api::typecheck`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add api/src/api.ts api/src/index.ts
+git commit -m "feat(api): add /weather endpoint proxying OpenWeather"
+```
+
+---
+
+### Task 3: Update frontend `fetchWeather()` to call the Worker
+
+**Files:**
+- Modify: `app/src/scripts/live-window/api.ts:74-104`
+
+**Step 1: Change `fetchWeather` signature and implementation**
+
+Replace the `fetchWeather` function. Remove the `owKey` parameter, add `apiUrl` parameter. Call the Worker's `/weather` endpoint instead of OpenWeather directly:
+
+```typescript
+export async function fetchWeather(
+  apiUrl: string,
+  state: StoreState,
+  units: string,
+): Promise<{ state: StoreState; changed: boolean }> {
+  const { lat, lng } = state.location;
+  if (lat == null || lng == null) return { state, changed: false };
+
+  try {
+    const res = await fetch(
+      `${apiUrl}/weather?units=${units}&lat=${lat}&lon=${lng}`,
+    );
+    if (!res.ok) return { state, changed: false };
+    const data = await res.json();
+
+    const newState: StoreState = {
+      ...state,
+      weather: {
+        current: { main: data.main, description: data.description, icon: data.icon, temp: data.temp },
+        sunrise: data.sunrise * 1000,
+        sunset: data.sunset * 1000,
+        units,
+        lastFetched: Date.now(),
+      },
+    };
+
+    return { state: newState, changed: true };
+  } catch {
+    return { state, changed: false };
+  }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add app/src/scripts/live-window/api.ts
+git commit -m "feat(app): fetchWeather calls Worker instead of OpenWeather directly"
+```
+
+---
+
+### Task 4: Update `LiveWindow.ts` to remove `openweather-key` attribute
+
+**Files:**
+- Modify: `app/src/scripts/live-window/LiveWindow.ts`
+
+**Step 1: Remove `"openweather-key"` from `observedAttributes`**
+
+Remove `"openweather-key",` from the `static observedAttributes` array (line 16).
+
+**Step 2: Update `attributeChangedCallback`**
+
+Remove the condition at lines 96-98 that checks for `openweather-key`:
+
+```typescript
+    if (this.getAttribute("openweather-key") && this.getAttribute("api-url") && !this.weatherInterval) {
+      this.startWeatherPolling();
+    }
+```
+
+Replace with:
+
+```typescript
+    if (this.getAttribute("api-url") && !this.weatherInterval) {
+      this.startWeatherPolling();
+    }
+```
+
+**Step 3: Update `startUpdates`**
+
+Replace the condition at lines 196-203:
+
+```typescript
+    const hasExplicitCoords = this.getAttribute("latitude") != null && this.getAttribute("longitude") != null;
+
+    if (
+      (hasExplicitCoords && this.getAttribute("openweather-key")) ||
+      (this.getAttribute("openweather-key") && this.getAttribute("api-url"))
+    ) {
+      this.startWeatherPolling();
+    }
+```
+
+With:
+
+```typescript
+    const apiUrl = this.getAttribute("api-url");
+    const hasExplicitCoords = this.getAttribute("latitude") != null && this.getAttribute("longitude") != null;
+
+    if (apiUrl && (hasExplicitCoords || true)) {
+      this.startWeatherPolling();
+    }
+```
+
+Wait — simplify. The condition was: need an OW key AND either explicit coords or api-url. Now OW key is on the Worker, so the condition is just: need `api-url`.
+
+```typescript
+    if (this.getAttribute("api-url")) {
+      this.startWeatherPolling();
+    }
+```
+
+**Step 4: Update `doFetchWeather`**
+
+Replace the method. Key changes:
+- Remove `owKey` check — no longer needed
+- Always require `apiUrl`
+- Pass `apiUrl` to `fetchWeather` instead of `owKey`
+- For explicit coords, still need `apiUrl` for the weather call
+
+```typescript
+  private async doFetchWeather(): Promise<void> {
+    const apiUrl = this.getAttribute("api-url");
+    if (!apiUrl) return;
+
+    const explicitLat = this.getAttribute("latitude");
+    const explicitLng = this.getAttribute("longitude");
+    const hasExplicitCoords = explicitLat != null && explicitLng != null;
+
+    if (hasExplicitCoords) {
+      this.state.store = {
+        ...this.state.store,
+        location: {
+          lat: parseFloat(explicitLat),
+          lng: parseFloat(explicitLng),
+          country: null,
+          name: null,
+          timezone: null,
+          lastFetched: Date.now(),
+        },
+      };
+    } else {
+      if (!shouldFetchWeather(this.state.store, this.state.attrs.resolvedUnits)) {
+        this.updateAll();
+        return;
+      }
+
+      this.state.store = await fetchLocation(apiUrl, this.state.store);
+      saveState(this.state);
+    }
+
+    this.refreshAttrs();
+    const units = this.state.attrs.resolvedUnits;
+
+    if (!shouldFetchWeather(this.state.store, units) && !hasExplicitCoords) {
+      this.updateAll();
+      return;
+    }
+
+    const result = await fetchWeather(apiUrl, this.state.store, units);
+    this.state.store = result.state;
+
+    if (!hasExplicitCoords) {
+      saveState(this.state);
+    }
+
+    if (result.changed) {
+      this.updateAll();
+      this.dispatchEvent(
+        new CustomEvent("live-window:weather-update", {
+          detail: { weather: this.state.store.weather },
+        }),
+      );
+    }
+  }
+```
+
+**Step 5: Commit**
+
+```bash
+git add app/src/scripts/live-window/LiveWindow.ts
+git commit -m "feat(app): remove openweather-key attribute, use api-url for weather"
+```
+
+---
+
+### Task 5: Remove `PUBLIC_OPENWEATHER_KEY` from pages, env, and CI
+
+**Files:**
+- Modify: `app/src/pages/index.astro`
+- Modify: `app/src/pages/live-window-test.astro`
+- Modify: `app/.env.example`
+- Modify: `.github/workflows/deploy.yml`
+
+**Step 1: Update `index.astro`**
+
+Remove line 8: `const openweatherKey = import.meta.env.PUBLIC_OPENWEATHER_KEY || "";`
+
+Remove `openweather-key={openweatherKey}` from the `<live-window>` tag on line 25.
+
+**Step 2: Update `live-window-test.astro`**
+
+Remove line 4: `const openweatherKey = import.meta.env.PUBLIC_OPENWEATHER_KEY || "";`
+
+Remove `openweather-key={openweatherKey}` from the `<live-window>` tag on line 29.
+
+Add `api-url` attribute so the test page can fetch weather through the Worker. Add this to the frontmatter:
+
+```typescript
+const apiBaseUrl = import.meta.env.PUBLIC_API_BASE_URL || "";
+```
+
+Add `api-url={apiBaseUrl}` to the `<live-window>` tag.
+
+**Step 3: Update `app/.env.example`**
+
+Remove the three lines about OpenWeather (lines 11-13):
+```
+# OpenWeather API key for the live window weather display.
+# Get one at https://openweathermap.org/api
+PUBLIC_OPENWEATHER_KEY=
+```
+
+**Step 4: Update `.github/workflows/deploy.yml`**
+
+Remove line 108: `PUBLIC_OPENWEATHER_KEY: ${{ secrets.PUBLIC_OPENWEATHER_KEY }}`
+
+**Step 5: Run type check and build**
+
+Run: `just app::typecheck`
+Expected: No errors
+
+Run: `just app::build`
+Expected: Build succeeds
+
+**Step 6: Commit**
+
+```bash
+git add app/src/pages/index.astro app/src/pages/live-window-test.astro app/.env.example .github/workflows/deploy.yml
+git commit -m "feat(app): remove PUBLIC_OPENWEATHER_KEY from client-side code and CI"
+```
+
+---
+
+### Task 6: Update README
+
+**Files:**
+- Modify: `app/src/scripts/live-window/README.md`
+
+**Step 1: Update attribute table**
+
+Remove the `openweather-key` row. Update the description of `api-url` to mention it's used for both geolocation and weather.
+
+**Step 2: Update data flow description**
+
+Update the sections that describe how weather fetching works to reflect the new proxy pattern.
+
+**Step 3: Commit**
+
+```bash
+git add app/src/scripts/live-window/README.md
+git commit -m "docs: update live-window README for weather API proxy"
+```

--- a/just/api.just
+++ b/just/api.just
@@ -1,49 +1,11 @@
 set unstable
 set working-directory := '../api'
 
-app_dir := justfile_directory() / ".." / "app"
-
 # ─── Serve ────────────────────────────────────────────────────────────
 
-[doc("Run the API locally (env: dev or preview)")]
-[arg('env', long, help="dev (default) or preview (tunnel for sharing)", pattern="dev|preview")]
-[script('bash')]
-serve env="dev":
-    set -euo pipefail
-    if [ "{{env}}" != "preview" ]; then
-        exec npm run dev
-    fi
-    APP_DIR="{{app_dir}}"
-    LOG=$(mktemp)
-    cleanup() {
-        kill $PID 2>/dev/null
-        echo ""
-        rm -f "$APP_DIR/.env.production"
-        echo "Removed app/.env.production"
-        rm -f "$LOG"
-    }
-    trap cleanup EXIT INT TERM
-    echo "Starting API tunnel on http://localhost:8787..."
-    npx cloudflared tunnel --url http://localhost:8787 > "$LOG" 2>&1 &
-    PID=$!
-    echo "Waiting for tunnel URL..."
-    URL=""
-    for i in $(seq 1 30); do
-        URL=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$LOG" 2>/dev/null | head -1 || true)
-        if [ -n "$URL" ]; then break; fi
-        sleep 1
-    done
-    if [ -z "$URL" ]; then
-        echo "ERROR: Could not get tunnel URL after 30s. Check that port 8787 is running."
-        exit 1
-    fi
-    echo "PUBLIC_API_BASE_URL=$URL" > "$APP_DIR/.env.production"
-    echo ""
-    echo "API tunnel:  $URL"
-    echo "Written to app/.env.production — now run 'just app::serve --env preview' in another terminal"
-    echo "Press Ctrl+C to stop (removes app/.env.production)"
-    echo ""
-    wait $PID
+[doc("Run the API locally")]
+serve:
+    npm run dev
 
 # ─── Test ─────────────────────────────────────────────────────────────
 

--- a/just/api.just
+++ b/just/api.just
@@ -37,11 +37,9 @@ serve env="dev":
         echo "ERROR: Could not get tunnel URL after 30s. Check that port 8787 is running."
         exit 1
     fi
-    WS_URL="wss://${URL#https://}/ws"
-    echo "PUBLIC_CHAT_WS_URL=$WS_URL" > "$APP_DIR/.env.production"
+    echo "PUBLIC_API_BASE_URL=$URL" > "$APP_DIR/.env.production"
     echo ""
     echo "API tunnel:  $URL"
-    echo "WS URL:      $WS_URL"
     echo "Written to app/.env.production — now run 'just app::serve --env preview' in another terminal"
     echo "Press Ctrl+C to stop (removes app/.env.production)"
     echo ""

--- a/just/app.just
+++ b/just/app.just
@@ -3,44 +3,9 @@ set working-directory := '../app'
 
 # ─── Serve ────────────────────────────────────────────────────────────
 
-[doc("Run the frontend locally (env: dev or preview)")]
-[arg('env', long, help="dev (default) or preview (tunnel for sharing)", pattern="dev|preview")]
-[script('bash')]
-serve env="dev":
-    set -euo pipefail
-    if [ "{{env}}" != "preview" ]; then
-        exec npm run dev
-    fi
-    npm run build
-    LOG=$(mktemp)
-    cleanup() {
-        kill $TUNNEL_PID 2>/dev/null
-        kill $PREVIEW_PID 2>/dev/null
-        rm -f "$LOG"
-    }
-    trap cleanup EXIT INT TERM
-    echo "Starting preview server on port 4322..."
-    npm run preview > /dev/null 2>&1 &
-    PREVIEW_PID=$!
-    sleep 2
-    echo "Starting frontend tunnel on http://localhost:4322..."
-    npx cloudflared tunnel --url http://localhost:4322 > "$LOG" 2>&1 &
-    TUNNEL_PID=$!
-    URL=""
-    for i in $(seq 1 30); do
-        URL=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$LOG" 2>/dev/null | head -1 || true)
-        if [ -n "$URL" ]; then break; fi
-        sleep 1
-    done
-    if [ -z "$URL" ]; then
-        echo "ERROR: Could not get tunnel URL after 30s."
-        exit 1
-    fi
-    echo ""
-    echo "Share this URL: $URL"
-    echo "Press Ctrl+C to stop"
-    echo ""
-    wait $TUNNEL_PID
+[doc("Run the frontend locally")]
+serve:
+    npm run dev
 
 # ─── Test ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

### API Worker
- Add `/location` endpoint proxying ipregistry for IP geolocation
- Add `/weather` endpoint proxying OpenWeather with param validation
- Add tests for both new endpoints; update wrangler config and `.dev.vars.example`

### Frontend
- Route all weather and geolocation calls through the Worker instead of calling third-party APIs directly
- Remove `PUBLIC_OPENWEATHER_KEY` from client-side code, env files, and CI
- Use ipregistry location data (city/region/country) for the live-window display instead of OpenWeather city name

### Env simplification
- Derive `PUBLIC_CHAT_WS_URL` from `PUBLIC_API_BASE_URL` (`http→ws` + `/ws`), removing a redundant env var from `.env` files, CI workflow, and the tunnel preview script

## Post-merge cleanup

Remove from GitHub repo variables and Cloudflare Pages dashboard:
- `PUBLIC_CHAT_WS_URL` / `PUBLIC_CHAT_WS_URL_PREVIEW`
- `PUBLIC_OPENWEATHER_KEY` (if set)

## Test plan
- [x] `just app::typecheck` passes
- [x] `just test` — 59 API + 231 app tests pass
- [x] `just lint` clean
- [x] `just format --check` clean
- [ ] Verify weather + location load in live-window locally
- [ ] Verify chat connects in local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)