### PR TITLE
fix: correct live URLs and GitHub links for site version posts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,4 +32,4 @@
 - [ ] audit all tests - mock [moderation] skipped: OPENAI_API_KEY not set
 - [ ] Fix top-[35px]
 - [x] Add moon and sun layers to sky component
-- [ ] Update site urls for older versions
+- [x] Update site urls for older versions

--- a/app/src/content/versions/2022-super-window.md
+++ b/app/src/content/versions/2022-super-window.md
@@ -12,7 +12,7 @@ coverImageAlt: A screenshot of the thalida.com homepage, showcasing a Notion-bac
 
 | Year | GitHub | Link |
 | ---- | ------ | ---- |
-| Jan 2022 - Jul 2025 | [Github](https://github.com/thalida/thalida.com/tree/v-2022) | [Live](https://thalida.com) |
+| Jan 2022 - Jul 2025 | [Github](https://github.com/thalida/thalida.com/tree/v-2022) | [Live](https://2022.v.thalida.com) |
 
 
 ## 💡Idea

--- a/app/src/content/versions/2025-astro-animated.md
+++ b/app/src/content/versions/2025-astro-animated.md
@@ -10,6 +10,10 @@ coverImageAlt: "Animated window effect showing weather and time"
 
 ![Screenshot of the 2025 site](<2025-astro-animated/Screenshot 2025-07-03 at 16.48.24.png>)
 
+| Year | GitHub | Link |
+| ---- | ------ | ---- |
+| Jul 2025 - Present | [Github](https://github.com/thalida/thalida.com) | [Live](https://2025.v.thalida.com) |
+
 
 ## Goals
 

--- a/app/src/content/versions/2025-astro-animated.md
+++ b/app/src/content/versions/2025-astro-animated.md
@@ -12,7 +12,7 @@ coverImageAlt: "Animated window effect showing weather and time"
 
 | Year | GitHub | Link |
 | ---- | ------ | ---- |
-| Jul 2025 - Present | [Github](https://github.com/thalida/thalida.com) | [Live](https://2025.v.thalida.com) |
+| Jul 2025 - Feb 2026 | [Github](https://github.com/thalida/thalida.com/tree/v-2025) | [Live](https://2025.v.thalida.com) |
 
 
 ## Goals


### PR DESCRIPTION
## Summary
- Fixed 2022 post live URL from `thalida.com` to `2022.v.thalida.com`
- Added missing info table (Year/GitHub/Link) to 2025 post with correct `v-2025` branch link and `2025.v.thalida.com` live URL
- Set 2025 version end date to Feb 2026

## Test plan
- [ ] Verify version post pages render correctly with updated URLs
- [ ] Confirm `2022.v.thalida.com` and `2025.v.thalida.com` resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)