### PR TITLE
feat: add VS Code launch configs for dev servers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "API: Serve",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "just api::serve"
+    },
+    {
+      "name": "App: Serve",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "just app::serve"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "API + App: Serve",
+      "configurations": ["API: Serve", "App: Serve"]
+    }
+  ]
+}

--- a/TODO.md
+++ b/TODO.md
@@ -36,4 +36,4 @@
 - [x] Update site urls for older versions
 - [ ] show plan docs on site
 - [ ] add site footer
-- [ ] add vscode tasks to run app / api
+- [x] add vscode tasks to run app / api


### PR DESCRIPTION
## Summary
- Adds `.vscode/launch.json` with Run and Debug configurations for **API: Serve**, **App: Serve**, and a compound **API + App: Serve**
- Marks the "add vscode tasks to run app / api" TODO as complete

## Test plan
- [ ] Open Run and Debug panel in VS Code and verify the three configurations appear
- [ ] Run "API: Serve" and confirm API starts on localhost:8787
- [ ] Run "App: Serve" and confirm app starts on localhost:4321
- [ ] Run "API + App: Serve" and confirm both start simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)