### PR TITLE
fix: align live window weather polling with rate limit

### DIFF
--- a/app/src/scripts/live-window/LiveWindow.ts
+++ b/app/src/scripts/live-window/LiveWindow.ts
@@ -4,7 +4,7 @@ import { resolveUnits, shouldFetchWeather, fetchLocation, fetchWeather, location
 import { parseHexColor, parseComputedColor } from "./utils/color";
 import {
   ONE_DAY_MS,
-  ONE_HOUR_MS,
+  THIRTY_MINUTES_MS,
   CLOCK_INTERVAL_MS,
   SKY_UPDATE_INTERVAL_MS,
   MIN_TICK_SPEED,
@@ -356,7 +356,19 @@ class LiveWindowElement extends HTMLElement {
 
   private startWeatherPolling() {
     this.doFetchWeather();
-    this.weatherInterval = window.setInterval(() => this.doFetchWeather(), ONE_HOUR_MS);
+
+    // Schedule next poll for when the rate limit actually expires, not
+    // blindly 30 min from now.  If lastFetched is recent the immediate
+    // doFetchWeather above was a no-op, so we wait only the remaining
+    // time before the window opens, then switch to a steady 30-min cadence.
+    const lastFetched = this.state.store.weather.lastFetched;
+    const elapsed = lastFetched ? Date.now() - lastFetched : THIRTY_MINUTES_MS;
+    const firstDelay = Math.max(0, THIRTY_MINUTES_MS - elapsed);
+
+    window.setTimeout(() => {
+      this.doFetchWeather();
+      this.weatherInterval = window.setInterval(() => this.doFetchWeather(), THIRTY_MINUTES_MS);
+    }, firstDelay);
   }
 
   private stopUpdates() {

--- a/app/src/scripts/live-window/components/InfoPanelComponent.ts
+++ b/app/src/scripts/live-window/components/InfoPanelComponent.ts
@@ -7,6 +7,7 @@ export class InfoPanelComponent implements SceneComponent {
   private locationEl: HTMLParagraphElement | null = null;
   private coordsEl: HTMLParagraphElement | null = null;
   private weatherEl: HTMLParagraphElement | null = null;
+  private lastFetchedEl: HTMLParagraphElement | null = null;
 
   mount(container: HTMLElement): void {
     this.containerEl = container;
@@ -32,6 +33,12 @@ export class InfoPanelComponent implements SceneComponent {
     wrapper.appendChild(coords);
     this.coordsEl = coords;
 
+    const lastFetched = document.createElement("p");
+    lastFetched.className = "info-panel-last-fetched";
+    lastFetched.hidden = true;
+    wrapper.appendChild(lastFetched);
+    this.lastFetchedEl = lastFetched;
+
     container.appendChild(wrapper);
   }
 
@@ -39,6 +46,7 @@ export class InfoPanelComponent implements SceneComponent {
     this.updateLocation(state);
     this.updateCoords(state);
     this.updateWeather(state);
+    this.updateLastFetched(state);
   }
 
   private updateLocation(state: LiveWindowState): void {
@@ -81,11 +89,25 @@ export class InfoPanelComponent implements SceneComponent {
     }
   }
 
+  private updateLastFetched(state: LiveWindowState): void {
+    if (!this.lastFetchedEl) return;
+    const lastFetched = state.store.weather.lastFetched;
+    if (lastFetched) {
+      const date = new Date(lastFetched);
+      const time = date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+      this.lastFetchedEl.textContent = `[updated ${time}]`;
+      this.lastFetchedEl.hidden = false;
+    } else {
+      this.lastFetchedEl.hidden = true;
+    }
+  }
+
   destroy(): void {
     if (this.containerEl) this.containerEl.innerHTML = "";
     this.containerEl = null;
     this.locationEl = null;
     this.coordsEl = null;
     this.weatherEl = null;
+    this.lastFetchedEl = null;
   }
 }

--- a/app/src/scripts/live-window/live-window.css
+++ b/app/src/scripts/live-window/live-window.css
@@ -751,8 +751,17 @@
   letter-spacing: 0.04em;
 }
 
+.info-panel-last-fetched {
+  font-size: var(--info-panel-last-fetched-size, 0.6rem);
+  margin: 0;
+  opacity: 0.7;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .info-panel-location[hidden],
 .info-panel-coords[hidden],
-.info-panel-weather[hidden] {
+.info-panel-weather[hidden],
+.info-panel-last-fetched[hidden] {
   display: none;
 }


### PR DESCRIPTION
## Summary
- **Bug fix:** Weather polling interval was 60 min but the rate limit allowed fetches every 30 min, causing stale weather data until page refresh. Now the first poll is scheduled for when the rate limit expires, then continues on a 30-min cadence.
- **Feature:** Added an `[UPDATED <time>]` timestamp to the info panel below the live window so users can see when weather was last fetched.

## Test plan
- [ ] Verify weather updates automatically without page refresh within 30 min
- [ ] Confirm `[UPDATED X:XX PM]` shows below the live window info panel
- [ ] Check that refreshing mid-cycle picks up new weather when rate limit has passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)