### PR TITLE
fix: refresh weather and sky when tab regains focus

### DIFF
--- a/app/src/scripts/live-window/LiveWindow.ts
+++ b/app/src/scripts/live-window/LiveWindow.ts
@@ -145,6 +145,7 @@ class LiveWindowElement extends HTMLElement {
   private clockInterval: number | null = null;
   private skyInterval: number | null = null;
   private weatherInterval: number | null = null;
+  private visibilityAC: AbortController | null = null;
 
   private virtualTime: number | null = null;
   private virtualTimeAnchorReal: number | null = null;
@@ -352,6 +353,22 @@ class LiveWindowElement extends HTMLElement {
     } else {
       this.markCelestialReady();
     }
+
+    // Refresh weather + sky immediately when the tab regains focus.
+    // Browsers throttle/suspend setInterval in background tabs, so the
+    // regular 30-min polling may never fire while hidden.
+    this.visibilityAC = new AbortController();
+    document.addEventListener(
+      "visibilitychange",
+      () => {
+        if (document.hidden) return;
+        this.updateAll();
+        if (this.getAttribute("api-url")) {
+          this.doFetchWeather();
+        }
+      },
+      { signal: this.visibilityAC.signal },
+    );
   }
 
   private startWeatherPolling() {
@@ -375,9 +392,11 @@ class LiveWindowElement extends HTMLElement {
     if (this.clockInterval != null) clearInterval(this.clockInterval);
     if (this.skyInterval != null) clearInterval(this.skyInterval);
     if (this.weatherInterval != null) clearInterval(this.weatherInterval);
+    this.visibilityAC?.abort();
     this.clockInterval = null;
     this.skyInterval = null;
     this.weatherInterval = null;
+    this.visibilityAC = null;
   }
 
   private markCelestialReady() {


### PR DESCRIPTION
## Summary
- Browsers throttle/suspend `setInterval` in background tabs, so the 30-min weather polling never fires while hidden
- When returning to the tab after a long absence, the clock was correct (reads `Date.now()` each tick) but weather data and sky visuals were stale
- Added a `visibilitychange` listener that immediately updates the sky and triggers a weather fetch on tab focus (existing rate-limit guard prevents redundant API calls)

## Test plan
- [ ] Open the live window page, note the weather/sky state
- [ ] Switch to another tab and wait 30+ minutes (or throttle the tab via DevTools)
- [ ] Switch back — weather should refresh and sky should update to current time immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)