### PR TITLE
fix: move related posts below post content

### DIFF
--- a/app/src/pages/[collection]/post/[...id].astro
+++ b/app/src/pages/[collection]/post/[...id].astro
@@ -248,23 +248,6 @@ const recipeMeta =
       }
       <CardTags tags={entry.data.tags} max={Infinity} />
       {
-        relatedItems.length > 0 && (
-          <div class="mt-4 pt-3 border-t border-border">
-            <p class="m-0 mb-2 text-xs font-body font-semibold text-muted uppercase tracking-widest">Related</p>
-            <div class="flex flex-col gap-1">
-              {relatedItems.map((ri) => (
-                <a
-                  href={`/${collection}/post/${ri.id}`}
-                  class="flex items-center gap-2 text-sm text-teal no-underline hover:text-neon font-body"
-                >
-                  <span>{ri.title}</span>
-                </a>
-              ))}
-            </div>
-          </div>
-        )
-      }
-      {
         recipeMeta.length > 0 && (
           <div class="recipe-meta flex flex-wrap gap-x-5 gap-y-1 mt-3 text-xs font-body text-muted">
             {recipeMeta.map(({ label, value }) => (
@@ -280,6 +263,23 @@ const recipeMeta =
     <div class="post-content prose prose-invert prose-sm max-w-none text-text font-body">
       {Content ? <Content /> : <p>Content could not be rendered.</p>}
     </div>
+    {
+      relatedItems.length > 0 && (
+        <div class="mt-8 pt-4 border-t border-border">
+          <p class="m-0 mb-2 text-xs font-body font-semibold text-muted uppercase tracking-widest">Related</p>
+          <div class="flex flex-col gap-1">
+            {relatedItems.map((ri) => (
+              <a
+                href={`/${collection}/post/${ri.id}`}
+                class="flex items-center gap-2 text-sm text-teal no-underline hover:text-neon font-body"
+              >
+                <span>{ri.title}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )
+    }
   </article>
 </BaseLayout>
 


### PR DESCRIPTION
## Summary
- Moves the "Related" posts section from the post sidebar/meta area to below the post content
- Adjusts spacing to better fit the new position (`mt-8 pt-4`)

## Test plan
- [ ] Verify related posts appear below post content on posts that have related items
- [ ] Verify posts without related items are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)