### PR TITLE
feat(content): order collections by last updated, and show both dates

### DIFF
--- a/app/src/components/Card/CardDate.astro
+++ b/app/src/components/Card/CardDate.astro
@@ -1,0 +1,22 @@
+---
+import type { NavItem } from "@lib/nav-data";
+import { formatDate, isValidDate } from "@lib/format-utils";
+
+interface Props {
+  item: NavItem;
+  class?: string;
+}
+
+const { item, class: className } = Astro.props;
+
+// Every card shows one date in the same shape: the one the list is sorted by.
+const iso = item.updatedOn && isValidDate(item.updatedOn) ? item.updatedOn : item.publishedOn;
+---
+
+{
+  isValidDate(iso) && (
+    <span class:list={["text-dim text-2xs ml-auto shrink-0", className]} data-ts={iso}>
+      {formatDate(iso)}
+    </span>
+  )
+}

--- a/app/src/components/Card/CompactCard.astro
+++ b/app/src/components/Card/CompactCard.astro
@@ -1,7 +1,7 @@
 ---
 import type { NavItem } from "@lib/nav-data";
-import { formatDate, isValidDate } from "@lib/format-utils";
 import CardCategory from "./CardCategory.astro";
+import CardDate from "./CardDate.astro";
 import CardTags from "./CardTags.astro";
 
 interface Props {
@@ -16,13 +16,7 @@ const href = `/${item.collection}/post/${item.id}`;
 <a href={href} class="group item-card flex flex-col p-3 gap-1">
   <div class="flex items-center gap-2">
     <CardCategory category={item.category} subcategory={item.subcategory} />
-    {
-      isValidDate(item.publishedOn) && (
-        <span class="text-dim text-2xs ml-auto shrink-0" data-ts={item.publishedOn}>
-          {formatDate(item.publishedOn)}
-        </span>
-      )
-    }
+    <CardDate item={item} />
   </div>
   <h3 class="m-0 font-heading font-bold text-text leading-snug text-base">{item.title}</h3>
   {item.description && <p class="m-0 font-body text-muted leading-relaxed text-xs line-clamp-3">{item.description}</p>}

--- a/app/src/components/Card/GalleryCard.astro
+++ b/app/src/components/Card/GalleryCard.astro
@@ -1,7 +1,7 @@
 ---
 import type { NavItem } from "@lib/nav-data";
-import { formatDate, isValidDate } from "@lib/format-utils";
 import CardCategory from "./CardCategory.astro";
+import CardDate from "./CardDate.astro";
 import CardCover from "./CardCover.astro";
 import CardTags from "./CardTags.astro";
 
@@ -27,13 +27,7 @@ const href = `/${item.collection}/post/${item.id}`;
   <div class="p-3 flex flex-col gap-0.5">
     <div class="flex items-center gap-2">
       <CardCategory category={item.category} subcategory={item.subcategory} />
-      {
-        isValidDate(item.publishedOn) && (
-          <span class="text-dim text-2xs ml-auto" data-ts={item.publishedOn}>
-            {formatDate(item.publishedOn)}
-          </span>
-        )
-      }
+      <CardDate item={item} />
     </div>
     <h3 class="m-0 font-heading font-bold text-text text-sm leading-snug">{item.title}</h3>
     <div class="mt-auto pt-2">

--- a/app/src/components/Card/LinkCard.astro
+++ b/app/src/components/Card/LinkCard.astro
@@ -1,7 +1,7 @@
 ---
 import type { NavItem } from "@lib/nav-data";
-import { formatDate, isValidDate } from "@lib/format-utils";
 import CardCategory from "./CardCategory.astro";
+import CardDate from "./CardDate.astro";
 import CardTags from "./CardTags.astro";
 
 interface Props {
@@ -24,13 +24,7 @@ const displayUrl = (() => {
 <a href={href} class="item-card flex flex-col gap-1 p-3" target="_blank" rel="noopener">
   <div class="flex items-center gap-2">
     <CardCategory category={item.originalCategory ?? item.category} subcategory={item.subcategory} />
-    {
-      isValidDate(item.publishedOn) && (
-        <span class="text-dim text-2xs ml-auto" data-ts={item.publishedOn}>
-          {formatDate(item.publishedOn)}
-        </span>
-      )
-    }
+    <CardDate item={item} />
   </div>
   <h3 class="m-0 font-heading font-bold text-text leading-snug flex gap-2 text-base">
     {

--- a/app/src/components/Card/StackedCard.astro
+++ b/app/src/components/Card/StackedCard.astro
@@ -1,7 +1,7 @@
 ---
 import type { NavItem } from "@lib/nav-data";
-import { formatDate, isValidDate } from "@lib/format-utils";
 import CardCategory from "./CardCategory.astro";
+import CardDate from "./CardDate.astro";
 import CardCover from "./CardCover.astro";
 import CardTags from "./CardTags.astro";
 
@@ -27,13 +27,7 @@ const href = `/${item.collection}/post/${item.id}`;
   <div class="flex flex-col gap-1 p-3 flex-1">
     <div class="flex items-center gap-2">
       <CardCategory category={item.category} subcategory={item.subcategory} />
-      {
-        isValidDate(item.publishedOn) && (
-          <span class="text-dim text-2xs ml-auto" data-ts={item.publishedOn}>
-            {formatDate(item.publishedOn)}
-          </span>
-        )
-      }
+      <CardDate item={item} />
     </div>
     <h3 class="m-0 font-heading font-bold text-text leading-snug text-base">{item.title}</h3>
     {

--- a/app/src/components/CommandPalette/command-palette-render.ts
+++ b/app/src/components/CommandPalette/command-palette-render.ts
@@ -74,7 +74,8 @@ export function renderItem(
       slot("cover-placeholder").hidden = false;
       slot("initial").textContent = item.title.charAt(0);
     }
-    slot("date").textContent = formatDate(item.publishedOn);
+    // Mirror CardDate: one unlabeled date, the one the list is ordered by.
+    slot("date").textContent = formatDate(item.updatedOn ?? item.publishedOn);
   }
 
   return frag;

--- a/app/src/content.config.ts
+++ b/app/src/content.config.ts
@@ -20,44 +20,64 @@ export function isHiddenCollection(name: string): boolean {
 
 export type CardVariant = "stacked" | "link" | "compact" | "gallery";
 
-export const collectionMeta: Record<CollectionName, { title: string; description: string; cardVariant: CardVariant }> =
-  {
-    projects: {
-      title: "Projects",
-      description: "Personal and professional projects, crafts, and experiments.",
-      cardVariant: "stacked",
-    },
-    guides: {
-      title: "Guides",
-      description: "Step-by-step guides and tutorials.",
-      cardVariant: "stacked",
-    },
-    gallery: {
-      title: "Gallery",
-      description: "Photography, art, and visual projects.",
-      cardVariant: "gallery",
-    },
-    links: {
-      title: "Links",
-      description: "Curated resources, tools, and websites.",
-      cardVariant: "link",
-    },
-    recipes: {
-      title: "Recipes",
-      description: "Favorite recipes.",
-      cardVariant: "compact",
-    },
-    versions: {
-      title: "Site Versions",
-      description: "The evolution of thalida.com.",
-      cardVariant: "stacked",
-    },
-    plans: {
-      title: "Plans",
-      description: "Claude's design docs and implementation plans for thalida.com.",
-      cardVariant: "compact",
-    },
-  };
+/**
+ * The frontmatter date a collection is ordered by, everywhere its entries are
+ * listed: the sidebar, collection pages, the homepage, and the command palette.
+ * Newest first either way.
+ *
+ * - `updatedOn` — last updated, falling back to `publishedOn` for entries that
+ *   have never been revised. The default: a recently revised entry is current.
+ * - `publishedOn` — publish date alone, for chronologies where a later edit
+ *   should not move an entry out of sequence.
+ *
+ * Both modes break ties on `publishedOn`.
+ */
+export type SortMode = "updatedOn" | "publishedOn";
+
+export const DEFAULT_SORT: SortMode = "updatedOn";
+
+export const collectionMeta: Record<
+  CollectionName,
+  { title: string; description: string; cardVariant: CardVariant; sort?: SortMode }
+> = {
+  projects: {
+    title: "Projects",
+    description: "Personal and professional projects, crafts, and experiments.",
+    cardVariant: "stacked",
+  },
+  guides: {
+    title: "Guides",
+    description: "Step-by-step guides and tutorials.",
+    cardVariant: "stacked",
+  },
+  gallery: {
+    title: "Gallery",
+    description: "Photography, art, and visual projects.",
+    cardVariant: "gallery",
+  },
+  links: {
+    title: "Links",
+    description: "Curated resources, tools, and websites.",
+    cardVariant: "link",
+  },
+  recipes: {
+    title: "Recipes",
+    description: "Favorite recipes.",
+    cardVariant: "compact",
+  },
+  versions: {
+    title: "Site Versions",
+    description: "The evolution of thalida.com.",
+    cardVariant: "stacked",
+    // A chronology of the site: each version stays where it shipped.
+    sort: "publishedOn",
+  },
+  plans: {
+    title: "Plans",
+    description: "Claude's design docs and implementation plans for thalida.com.",
+    cardVariant: "compact",
+  },
+};
 
 async function combineYamlFiles({ filename, pattern, base }: { filename: string; pattern: string; base: string }) {
   const yamlFiles = fs.glob(pattern, { cwd: base });

--- a/app/src/lib/format-utils.ts
+++ b/app/src/lib/format-utils.ts
@@ -3,8 +3,29 @@ export function isValidDate(isoString: string): boolean {
   return !isNaN(d.getTime()) && d.getFullYear() > 1970;
 }
 
+/** Frontmatter dates are authored as bare UTC days, so render them in UTC —
+ *  otherwise a visitor west of UTC sees the day (and sometimes month) before. */
 export function formatDate(isoString: string): string {
-  return new Date(isoString).toLocaleDateString("en-US", { year: "numeric", month: "short" });
+  return new Date(isoString).toLocaleDateString("en-US", { year: "numeric", month: "short", timeZone: "UTC" });
+}
+
+/** "Nov 6, 2021" — the compact form used where horizontal room is tight. */
+export function formatShortDate(isoString: string | Date): string {
+  return new Date(isoString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export function formatLongDate(isoString: string | Date): string {
+  return new Date(isoString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
 }
 
 export function formatDateFull(isoString: string): string {

--- a/app/src/lib/nav-data.ts
+++ b/app/src/lib/nav-data.ts
@@ -1,10 +1,12 @@
 import { getCollection } from "astro:content";
 import {
   COLLECTION_NAMES,
+  DEFAULT_SORT,
   collectionMeta,
   isHiddenCollection,
   type CollectionName,
   type EntryData,
+  type SortMode,
 } from "../content.config";
 import { getLinkMetadataMap } from "./link-metadata";
 import { parseContentPath } from "./content-path";
@@ -20,6 +22,7 @@ export type NavItem = {
   category?: string;
   originalCategory?: string;
   publishedOn: string; // ISO string for JSON serialization
+  updatedOn?: string; // ISO string for JSON serialization
   coverImageSrc?: string;
   coverImageAlt?: string;
   faviconUrl?: string;
@@ -38,6 +41,22 @@ export type NavCollection = {
 export type NavEntry = { type: "page"; page: string; label: string } | { type: "collection"; collection: string };
 
 type AnyEntry = { id: string; data: EntryData };
+
+/** When an entry was last touched: its update date, else its publish date. */
+function lastUpdated(data: EntryData): number {
+  return new Date(data.updatedOn ?? data.publishedOn).getTime();
+}
+
+/** Newest first, by the collection's configured sort date. See `SortMode`. */
+function byDate(mode: SortMode) {
+  return (a: AnyEntry, b: AnyEntry) => {
+    if (mode === "updatedOn") {
+      const updated = lastUpdated(b.data) - lastUpdated(a.data);
+      if (updated !== 0) return updated;
+    }
+    return new Date(b.data.publishedOn).getTime() - new Date(a.data.publishedOn).getTime();
+  };
+}
 
 export const NAV_ORDER: NavEntry[] = [
   { type: "page", page: "", label: "Home" },
@@ -73,9 +92,7 @@ export async function getNavData(): Promise<Record<string, NavCollection>> {
     const entries = ((await getCollection(name as CollectionName)) as unknown as AnyEntry[]).filter(
       (entry) => !entry.data.draft,
     );
-    const sorted = entries.sort(
-      (a, b) => new Date(b.data.publishedOn).getTime() - new Date(a.data.publishedOn).getTime(),
-    );
+    const sorted = entries.sort(byDate(collectionMeta[name].sort ?? DEFAULT_SORT));
 
     const categoriesSet = new Set<string>();
     const items: NavItem[] = [];
@@ -101,6 +118,7 @@ export async function getNavData(): Promise<Record<string, NavCollection>> {
         category,
         originalCategory: isDead ? entry.data.category : undefined,
         publishedOn: entry.data.publishedOn.toISOString(),
+        updatedOn: entry.data.updatedOn?.toISOString(),
         coverImageSrc,
         coverImageAlt: entry.data.coverImageAlt,
         faviconUrl: isLink ? linkMeta?.faviconUrl : undefined,

--- a/app/src/pages/[collection]/post/[...id].astro
+++ b/app/src/pages/[collection]/post/[...id].astro
@@ -4,7 +4,7 @@ import { getCollection, render, type CollectionEntry } from "astro:content";
 import type { AstroComponentFactory } from "astro/runtime/server/index.js";
 import { COLLECTION_NAMES, isHiddenCollection, type CollectionName } from "@/content.config";
 import CardTags from "@components/Card/CardTags.astro";
-import { prettifySlug } from "@lib/format-utils";
+import { formatLongDate, formatShortDate, prettifySlug } from "@lib/format-utils";
 import { parseContentPath } from "@lib/content-path";
 import { resolveMediaUrl } from "@lib/constants";
 
@@ -168,6 +168,15 @@ const recipeMeta =
         { label: "Total", value: formatDuration(entry.data.totalTime) },
       ].filter((item) => item.value)
     : [];
+
+// An updatedOn equal to publishedOn is noise, not an edit. When there is a real
+// one it leads, since that is the date the collection is ordered by.
+const showUpdatedOn = !!entry.data.updatedOn && entry.data.updatedOn.getTime() !== entry.data.publishedOn?.getTime();
+
+const headerDates = [
+  ...(showUpdatedOn ? [{ label: "Updated", value: entry.data.updatedOn! }] : []),
+  ...(entry.data.publishedOn ? [{ label: "Created", value: entry.data.publishedOn }] : []),
+];
 ---
 
 <BaseLayout
@@ -193,7 +202,9 @@ const recipeMeta =
     <meta data-pagefind-meta={`itemId:${id}`} />
     <meta data-pagefind-meta={`tags:${(entry.data.tags || []).join(",")}`} />
     <header class="mb-6">
-      <div class="flex items-center gap-2 mb-2 font-body uppercase text-2xs tracking-widest">
+      <div
+        class="flex flex-col sm:flex-row sm:flex-wrap sm:items-baseline gap-x-2 gap-y-1 mb-2 font-body uppercase text-2xs tracking-widest"
+      >
         <p class="m-0 font-semibold">
           <a class="text-teal no-underline hover:text-neon" href={`/${collection}`}>{collection}</a>
           {
@@ -226,17 +237,18 @@ const recipeMeta =
           }
         </p>
         {
-          entry.data.publishedOn && (
-            <>
-              <span class="text-dim">·</span>
-              <time class="text-dim" data-ts={entry.data.publishedOn.toISOString()}>
-                {new Date(entry.data.publishedOn).toLocaleDateString("en-US", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })}
-              </time>
-            </>
+          headerDates.length > 0 && (
+            <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-dim">
+              {headerDates.map(({ label, value }, i) => (
+                <span class="whitespace-nowrap">
+                  <span class:list={["mr-2", { "hidden sm:inline": i === 0 }]}>·</span>
+                  <time data-ts={value.toISOString()}>
+                    {label} <span class="sm:hidden">{formatShortDate(value)}</span>
+                    <span class="hidden sm:inline">{formatLongDate(value)}</span>
+                  </time>
+                </span>
+              ))}
+            </div>
           )
         }
       </div>


### PR DESCRIPTION
## Why

Every listing — sidebar, collection pages, homepage, command palette — drew from one sort in `nav-data.ts` keyed on `publishedOn` alone. A post revised years after it shipped stayed buried: codecity, updated this week, sat **17th** in Projects behind its 2021 publish date.

## Ordering

Configurable per collection rather than hardcoded:

```ts
export type SortMode = "updatedOn" | "publishedOn";
export const DEFAULT_SORT: SortMode = "updatedOn";
```

`collectionMeta` takes an optional `sort`. Default `"updatedOn"` orders by `updatedOn ?? publishedOn`, ties broken on `publishedOn`. Only `versions` opts into `"publishedOn"` — it's a chronology of the site, so a later edit shouldn't move a version out of sequence.

## Visibility

So the order reads as intentional rather than random:

- **Cards** show one unlabeled date, the one they're sorted by. That block was duplicated across all four card variants; it now lives in a shared `CardDate` component.
- **Post headers** show both, updated first since that's what sorts. Narrow screens get the abbreviated month so the pair fits on one line, and drop the leading separator — a wrapped line opening on `·` reads as a bullet.

| | |
|---|---|
| Mobile (386px) | `PROJECTS / APP / CREATIVE`<br>`UPDATED AUG 21, 2026 · CREATED NOV 6, 2021` |
| Desktop | `PROJECTS / APP / CREATIVE · UPDATED AUGUST 21, 2026 · CREATED NOVEMBER 6, 2021` |

Posts without an `updatedOn` just show `CREATED …`.

## Drive-by fix

The header formatted dates without `timeZone`, so a `2021-11-06` frontmatter date rendered as **November 5** for anyone west of UTC. Production looked right only because CI builds in UTC. `formatDateFull` already pinned UTC; `formatDate` and the header now do too, via shared `formatLongDate` / `formatShortDate`. Visible effect: Devscript's `2025-02-01` was showing "Jan 2025", now "Feb 2025".

## Verification

- `just test` — 388 app + 87 api passing
- `just app::typecheck`, `just app::build` — clean, 305 pages
- Header checked in a real browser at 386px and desktop; listing order and rendered dates confirmed in the built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiS5VSXNxRx9pZ9gZfGRSt